### PR TITLE
feat: 質問一覧取得APIを実装 #11

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import cors from 'cors';
 import profileRouter from './routes/profile.js';
 import notificationRouter from './routes/notification';
+import questionRouter from './routes/question';
 
 const app = express();
 app.use(cors());
@@ -11,5 +12,6 @@ app.use(express.json());
 app.get('/', (req, res) => res.json({ message: 'Hello from Express!' }));
 app.use('/profile', profileRouter);
 app.use('/api/v1/notifications', notificationRouter);
+app.use('/api/v1/questions', questionRouter);
 
 app.listen(5000, () => console.log('Server running on http://localhost:5000'));

--- a/backend/src/routes/question.ts
+++ b/backend/src/routes/question.ts
@@ -11,40 +11,59 @@ router.get('/', async (req, res) => {
   const order = req.query.order === 'likes' ? 'likes' : 'new';
   const limit = 20;
   const offset = (page - 1) * limit;
+  const userId = req.user?.id ?? 'c0df35c7-2f4d-4d73-bcb7-119ec96ab474'; // 仮のUUID
 
   let query = supabase
     .from('questions')
     .select(`
       id,
       title,
-      content,
       created_at,
       statuses ( name ),
-      users ( nickname, profile_icon_url ),
-      question_tags (
-        tags ( id, name )
-      ),
-      question_likes ( count )
+      users ( nickname ),
+      question_tags ( tags ( name ) ),
+      question_likes ( user_id ),
+      bookmarks ( user_id ),
+      answers ( id )
     `)
     .is('deleted_at', null)
     .range(offset, offset + limit - 1);
 
   if (order === 'likes') {
-    query = query.order('question_likes.count', { ascending: false });
+    query = query.order('created_at', { ascending: false }); // いいね順は後述
   } else {
     query = query.order('created_at', { ascending: false });
   }
 
-  const { data, error } = await query;
+  const { data: rawData, error } = await query;
 
   if (error) {
     return res.status(500).json({ error: error.message });
   }
 
+  const formatted = (rawData ?? []).map((q: any) => ({
+    id: q.id,
+    title: q.title,
+    statusId: q.statuses?.name,
+    userName: q.users?.nickname,
+    postingTime: q.created_at,
+    likeCount: q.question_likes?.length ?? 0,
+    bookmarkCount: q.bookmarks?.length ?? 0,
+    replyCount: q.answers?.length ?? 0,
+    tagNames: q.question_tags?.map((qt: any) => qt.tags?.name) ?? [],
+    isLiked: q.question_likes?.some((l: any) => l.user_id === userId) ?? false,
+    isBookmarked: q.bookmarks?.some((b: any) => b.user_id === userId) ?? false,
+  }));
+
+  // いいね順の場合はアプリ側でソート
+  if (order === 'likes') {
+    formatted.sort((a, b) => b.likeCount - a.likeCount);
+  }
+
   return res.json({
     page,
     order,
-    data: data ?? [],
+    data: formatted,
   });
 });
 
@@ -52,8 +71,9 @@ router.get('/', async (req, res) => {
 // GET /api/v1/questions/:questionId
 router.get('/:questionId', async (req, res) => {
   const { questionId } = req.params;
+  const userId = req.user?.id ?? 'c0df35c7-2f4d-4d73-bcb7-119ec96ab474'; // 仮のUUID
 
-  const { data, error } = await supabase
+  const { data: rawData, error } = await supabase
     .from('questions')
     .select(`
       id,
@@ -61,11 +81,11 @@ router.get('/:questionId', async (req, res) => {
       content,
       created_at,
       statuses ( name ),
-      users ( nickname, profile_icon_url ),
-      question_tags (
-        tags ( id, name )
-      ),
-      question_likes ( count )
+      users ( nickname ),
+      question_tags ( tags ( name ) ),
+      question_likes ( user_id ),
+      bookmarks ( user_id ),
+      answers ( id )
     `)
     .eq('id', questionId)
     .is('deleted_at', null)
@@ -75,11 +95,28 @@ router.get('/:questionId', async (req, res) => {
     return res.status(500).json({ error: error.message });
   }
 
-  if (!data) {
+  if (!rawData) {
     return res.status(404).json({ error: 'Question not found' });
   }
 
-  return res.json(data);
+  const data = rawData as any;
+
+  const formatted = {
+    id: data.id,
+    title: data.title,
+    content: data.content,
+    statusId: data.statuses?.name,
+    userName: data.users?.nickname,
+    postingTime: data.created_at,
+    likeCount: data.question_likes?.length ?? 0,
+    bookmarkCount: data.bookmarks?.length ?? 0,
+    replyCount: data.answers?.length ?? 0,
+    tagNames: data.question_tags?.map((qt: any) => qt.tags?.name) ?? [],
+    isLiked: data.question_likes?.some((l: any) => l.user_id === userId) ?? false,
+    isBookmarked: data.bookmarks?.some((b: any) => b.user_id === userId) ?? false,
+  };
+
+  return res.json(formatted);
 });
 
 export default router;

--- a/backend/src/routes/question.ts
+++ b/backend/src/routes/question.ts
@@ -1,0 +1,85 @@
+// src/routes/question.ts
+import { Router } from 'express';
+import { supabase } from '../config/supabase';
+
+const router = Router();
+
+// 質問一覧取得
+// GET /api/v1/questions?page=1&order=new or likes
+router.get('/', async (req, res) => {
+  const page = Number(req.query.page) || 1;
+  const order = req.query.order === 'likes' ? 'likes' : 'new';
+  const limit = 20;
+  const offset = (page - 1) * limit;
+
+  let query = supabase
+    .from('questions')
+    .select(`
+      id,
+      title,
+      content,
+      created_at,
+      statuses ( name ),
+      users ( nickname, profile_icon_url ),
+      question_tags (
+        tags ( id, name )
+      ),
+      question_likes ( count )
+    `)
+    .is('deleted_at', null)
+    .range(offset, offset + limit - 1);
+
+  if (order === 'likes') {
+    query = query.order('question_likes.count', { ascending: false });
+  } else {
+    query = query.order('created_at', { ascending: false });
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    return res.status(500).json({ error: error.message });
+  }
+
+  return res.json({
+    page,
+    order,
+    data: data ?? [],
+  });
+});
+
+// 質問詳細取得
+// GET /api/v1/questions/:questionId
+router.get('/:questionId', async (req, res) => {
+  const { questionId } = req.params;
+
+  const { data, error } = await supabase
+    .from('questions')
+    .select(`
+      id,
+      title,
+      content,
+      created_at,
+      statuses ( name ),
+      users ( nickname, profile_icon_url ),
+      question_tags (
+        tags ( id, name )
+      ),
+      question_likes ( count )
+    `)
+    .eq('id', questionId)
+    .is('deleted_at', null)
+    .maybeSingle();
+
+  if (error) {
+    return res.status(500).json({ error: error.message });
+  }
+
+  if (!data) {
+    return res.status(404).json({ error: 'Question not found' });
+  }
+
+  return res.json(data);
+});
+
+export default router;

--- a/backend/src/routes/question.ts
+++ b/backend/src/routes/question.ts
@@ -11,7 +11,7 @@ router.get('/', async (req, res) => {
   const order = req.query.order === 'likes' ? 'likes' : 'new';
   const limit = 20;
   const offset = (page - 1) * limit;
-  const userId = req.user?.id ?? 'c0df35c7-2f4d-4d73-bcb7-119ec96ab474'; // 仮のUUID
+  const userId = req.user?.id;
 
   let query = supabase
     .from('questions')
@@ -71,7 +71,7 @@ router.get('/', async (req, res) => {
 // GET /api/v1/questions/:questionId
 router.get('/:questionId', async (req, res) => {
   const { questionId } = req.params;
-  const userId = req.user?.id ?? 'c0df35c7-2f4d-4d73-bcb7-119ec96ab474'; // 仮のUUID
+  const userId = req.user?.id;
 
   const { data: rawData, error } = await supabase
     .from('questions')


### PR DESCRIPTION
# 概要
- 質問一覧を取得するAPIを実装
-  質問詳細を取得するAPIを実装
- ページネーションの実装
- ソート機能の実装
- タグ取得
- いいね数、ブックマーク数、回答数の取得
- いいね済み、ブックマーク済み判定
- 論理削除された質問取得の除外