### PR TITLE
fix: 回答投稿時に質問ステータスを「整理中」へ自動変更

### DIFF
--- a/backend/src/routes/question.ts
+++ b/backend/src/routes/question.ts
@@ -401,6 +401,29 @@ router.post('/:questionId/answers', requireAuth, async (req, res) => {
     return res.status(500).json({ message: '回答の投稿に失敗しました' });
   }
 
+  if (!parentAnswerId) {
+    const { data: interiStatus } = await supabase
+      .from('statuses')
+      .select('id')
+      .eq('name', '整理中')
+      .single();
+
+    const { data: currentQuestion } = await supabase
+      .from('questions')
+      .select('statuses ( name )')
+      .eq('id', questionId)
+      .single();
+
+    const currentStatusName = (currentQuestion as any)?.statuses?.name;
+
+    if (interiStatus && currentStatusName !== '解決済み') {
+      await supabase
+        .from('questions')
+        .update({ status_id: interiStatus.id })
+        .eq('id', questionId);
+    }
+  }
+
   return res.status(201).json({ answerId: data.id });
 });
 

--- a/frontend/app/routes/question.tsx
+++ b/frontend/app/routes/question.tsx
@@ -75,8 +75,8 @@ function AnswererQuestionCard({ question }: AnswererQuestionCardProps) {
           ))}
         </div>
         <div className="flex items-center gap-2">
-          <Bookmark id={question.id} isBookmarked={question.isBookmarked ?? false} count={question.bookmarkCount} />
-          <Like id={question.id} type="question" isLiked={question.isLiked ?? false} count={question.likeCount} />
+          <Bookmark isBookmarked={question.isBookmarked ?? false} count={question.bookmarkCount} />
+          <Like isLiked={question.isLiked ?? false} count={question.likeCount} />
           <Comment count={question.replyCount} />
         </div>
       </div>
@@ -104,7 +104,7 @@ function AnswerPreviewCard({ answer }: AnswerPreviewCardProps) {
         {answer.content}
       </p>
       <div className="flex justify-end mt-2">
-        <Like id={answer.id} type="answer" count={answer.likeCount} isLiked={answer.isLiked} />
+        <Like count={answer.likeCount} isLiked={answer.isLiked} />
       </div>
     </Card>
   );
@@ -396,7 +396,8 @@ export default function QuestionPage() {
     try {
       await postAnswer({ questionId: id, content: answerContent });
       await refreshAnswers();
-      setQuestion((prev) => prev ? { ...prev, replyCount: prev.replyCount + 1 } : prev);
+      const updatedQuestion = await getQuestionById(id);
+      setQuestion(updatedQuestion);
       setIsAnswerModalOpen(false);
       setAnswerContent('');
       setAnswerError('');


### PR DESCRIPTION
## fix: 回答投稿時に質問ステータスを「整理中」へ自動変更

### 変更点

**変更ファイル: `backend/src/routes/question.ts`**

回答投稿API（`POST /api/v1/questions/:questionId/answers`）にステータス自動更新処理を追加

| | 内容 |
|---|---|
| 修正前 | 回答投稿後もステータスが「回答募集中」のまま変わらない |
| 修正後 | トップレベルの回答が投稿されたとき、ステータスを「整理中」に自動変更 |

- 返信（`parentAnswerId` あり）の場合はスキップ
- すでに「解決済み」の場合はスキップ

**変更ファイル: `frontend/app/routes/question.tsx`**

回答投稿後に質問データを再取得し、画面のステータス表示を即時反映

| | 内容 |
|---|---|
| 修正前 | 回答投稿後、ステータスがリロードするまで画面に反映されない |
| 修正後 | 回答投稿後に `getQuestionById` を呼び出し、ステータスを即時更新 |