### PR TITLE
refactor:昇順降順のコードのリファクタ

### DIFF
--- a/backend/src/routes/question.ts
+++ b/backend/src/routes/question.ts
@@ -157,8 +157,8 @@ const myActions = req.query['myActions[]']
 
 
 
-  if (order === 'likes_asc' || order === 'likes_desc') {
-  query = query.order('created_at', { ascending: false });
+  if (order === 'newAsc') {
+  query = query.order('created_at', { ascending: true });
     } else {
   query = query.order('created_at', { ascending: false });
     }
@@ -232,11 +232,11 @@ const myActions = req.query['myActions[]']
   }));
 
   // いいね順の場合はアプリ側でソート
-  if (order === 'likes_desc') {
-  formatted.sort((a, b) => b.likeCount - a.likeCount); // 降順
-} else if (order === 'likes_asc') {
-  formatted.sort((a, b) => a.likeCount - b.likeCount); // 昇順
-}
+  if (order === 'likesDesc') {
+  formatted.sort((a, b) => b.likeCount - a.likeCount);// 降順
+    } else if (order === 'likesAsc') {
+  formatted.sort((a, b) => a.likeCount - b.likeCount);// 昇順
+    }
 
   const totalCount = count ?? 0;
   const totalPages = Math.ceil(totalCount / limit);


### PR DESCRIPTION
## 概要
質問一覧取得APIのソート順がフロントから送られてくる値と一致していなかったため修正する。

## 変更内容
- DB側のソートを `newAsc` と `newDesc` に対応
- アプリ側のいいねソートを `likesAsc` と `likesDesc` に対応

## 関連イシュー
closes #140 

## 確認事項
- [ ] 投稿日昇順が正しく動作する
- [ ] 投稿日降順が正しく動作する
- [ ] いいね数昇順が正しく動作する
- [ ] いいね数降順が正しく動作する