### PR TITLE
fix: プロフィール画面の活動推移取得ができるようにBEとFEを修正

### DIFF
--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -231,7 +231,9 @@ router.get('/me/activity', requireAuth, async (req, res) => {
     query = query.gte('created_at', `${from}-01`);
   }
   if (to) {
-    query = query.lte('created_at', `${to}-31`);
+    const [y, m] = to.split('-');
+    const lastDay = new Date(Number(y), Number(m), 0).getDate(); // 💡 その月の最終日(30や28など)を自動計算
+    query = query.lte('created_at', `${to}-${lastDay}`);
   }
 
   const { data, error } = await query;

--- a/frontend/app/api/userService.ts
+++ b/frontend/app/api/userService.ts
@@ -51,14 +51,23 @@ export const getTopTags = async (): Promise<({ name: string, count: number })[]>
 }
 
 /**
- * ユーザーの活動推移取得
- * @param userId 
- * @returns 
+ * ユーザーの活動推移（月ごとの回答件数）を取得
+ * @param from 開始月 (フォーマット: "YYYY-MM")
+ * @param to 終了月 (フォーマット: "YYYY-MM")
+ * @returns 月ごとの件数配列
  */
-export const getActivity = async (): Promise<({ month: string, count: number })[]> => {
-    const response = await axiosClient.get<({ month: string, count: number })[]>(`users/me/activity`)
-    return response.data
-}
+export const getActivity = async (
+    from?: string,
+    to?: string
+): Promise<{ month: string; count: number }[]> => {
+
+    const response = await axiosClient.get<{ month: string; count: number }[]>(
+        `users/me/activity`,
+        { params: { from, to } }
+    );
+
+    return response.data;
+};
 
 
 const userService = {

--- a/frontend/app/routes/profile.tsx
+++ b/frontend/app/routes/profile.tsx
@@ -36,11 +36,20 @@ export default function Profile() {
 
         const fetchProfileData = async () => {
             try {
-                // 404エラー対策： getTopTags や getActivity のURLタイポが直るまでは個別取得にしてあります
+                const toDate = new Date();
+                const fromDate = new Date();
+                fromDate.setMonth(fromDate.getMonth() - 5); // 今月を含めて6ヶ月にするため「-5」
+
+                // YYYY-MM 形式に変換するヘルパー関数
+                const formatDate = (d: Date) => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+
+                const from = formatDate(fromDate); // 例: "2026-01"
+                const to = formatDate(toDate);     // 例: "2026-06"
+
                 const myDetails = await getMyData();
                 const recentlySolved = await getRecentlySolved();
                 const tagsData = await getTopTags();
-                const activityData = await getActivity();
+                const activityData = await getActivity(from, to);
 
                 setProfileData(myDetails);
                 setQuestions(recentlySolved);


### PR DESCRIPTION
# 概要
- BEの月の最終日が31日固定だったものを次の月のの１日未満の日という条件に修正しました。
- FEのrequestにfromとtoが必要だったため追加しました。
- FEで現在の月と５カ月前の月を取得して計６カ月間になるようにfromとtoを設定できるようにしました。