### PR TITLE
fix:プロフィールの最近解決した質問を2件取得する際のバグ修正

### DIFF
--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -184,7 +184,7 @@ router.get('/me/recently-solved', requireAuth, async (req, res) => {
     `)
     .eq('user_id', userId)
     .not('best_answer_at', 'is', null)
-    .is('deleted_at', null)
+    .is('questions.deleted_at', null)
     .order('best_answer_at', { ascending: false })
     .limit(2);
 
@@ -192,7 +192,7 @@ router.get('/me/recently-solved', requireAuth, async (req, res) => {
     return res.status(500).json({ error: answerError.message });
   }
 
-  const formatted = (bestAnswers ?? []).map((a: any) => {
+  const formatted = (bestAnswers ?? []).filter((a: any) => a.questions !== null).map((a: any) => {
     const q = a.questions;
     return {
       id: q.id,


### PR DESCRIPTION
## 概要
削除された質問のベストアンサーを取得した際に、バックエンドで `TypeError` が発生してクラッシュする不具合を修正しました。

## 関連Issue
- Close #150 

## 実装内容
- `backend/src/routes/users.ts` の `/me/recently-solved` エンドポイントを修正。
- `supabase` から取得したデータに対して `map` を適用する前に `.filter((a: any) => a.questions !== null)` を挟むようにし、論理/物理削除された質問が原因で `q.id` 等の読み込み時にエラーになるのを防ぎました。

## 動作確認結果
- [x] 削除された質問がある状態でも、APIがエラー（500）にならずに200 OKを返すこと
- [x] フロントエンド側で連鎖して発生していた `/images/default-avatar.png` の404（No route matches）エラーが解消されたこと