### PR TITLE
fix: AIチャット入力欄を textarea に変更して改行を可能にする

### DIFF
--- a/frontend/app/routes/createQuestion.tsx
+++ b/frontend/app/routes/createQuestion.tsx
@@ -196,7 +196,7 @@ export default function CreateQuestion() {
                 <div>
                     <div className="py-[var(--spacing-16)]">
                         <SectionTitle title="質問タイトル" isRequired>
-                            <button onClick={() => setIsAiOpen(!isAiOpen)} className="shadow-[var(--box-shadow)] cursor-pointer rounded-[16px] text-white bg-[image:var(--ai-color)] px-[var(--spacing-32)] py-[var(--spacing-16)]">
+                            <button onClick={() => setIsAiOpen(!isAiOpen)} className="transition-all hover:shadow-[var(--hover-box-shadow)] shadow-[var(--box-shadow)] cursor-pointer rounded-[16px] text-white bg-[image:var(--ai-color)] px-[var(--spacing-32)] py-[var(--spacing-16)]">
                                 AIに相談する
                             </button>
                         </SectionTitle>
@@ -241,7 +241,10 @@ export default function CreateQuestion() {
                         </div>
                         <p>AI サポートアシスタント</p>
                     </div>
-                    <CloseIcon className="cursor-pointer" onClick={() => setIsAiOpen(false)} />
+                    <div className="transition-all hover:text-[var(--dark-gray)]">
+                        <CloseIcon className="cursor-pointer " onClick={() => setIsAiOpen(false)} />
+
+                    </div>
                 </div>
 
                 {/* メッセージエリア */}
@@ -251,7 +254,7 @@ export default function CreateQuestion() {
                             const isAi = msg.role === "model";
                             return (
                                 <div key={msg.id} className={`flex w-full ${isAi ? "justify-start" : "justify-end"}`}>
-                                    <div className={`max-w-[80%] p-3 text-sm leading-relaxed whitespace-pre-wrap rounded-lg shadow-sm border ${isAi ? "bg-[#FDF3E7] border-[#FFEBD0] text-[#444]" : "bg-white border-gray-200 text-[#333]"}`}>
+                                    <div className={`!select-text max-w-[80%] p-3 text-sm leading-relaxed whitespace-pre-wrap rounded-lg shadow-sm border ${isAi ? "bg-[#FDF3E7] border-[#FFEBD0] text-[#444]" : "bg-white border-gray-200 text-[#333]"}`}>
                                         {msg.text}
                                     </div>
                                 </div>
@@ -269,16 +272,17 @@ export default function CreateQuestion() {
 
                 {/* 入力エリア */}
                 <div className="px-4 pt-3 pb-4 border-t border-[var(--light-gray)] bg-white flex flex-col gap-1">
-                    <div className="flex gap-2 items-center">
-                        <input
-                            type="text"
+                    <div className="flex gap-2 items-end">
+                        <textarea
                             value={aiInputText}
                             onChange={(e) => setAiInputText(e.target.value)}
                             onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); submitAiChat(); } }}
                             placeholder="質問したい内容を入力..."
                             maxLength={AI_INPUT_MAX}
-                            className={`px-[var(--spacing-16)] flex-1 h-[44px] border rounded-[16px] focus:outline-none ${aiInputText.length > AI_INPUT_MAX ? 'border-[var(--danger-color)]' : 'border-[var(--light-gray)] focus:border-[#FF9500]'}`}
+                            rows={1}
+                            className={`px-[var(--spacing-16)] py-[10px] flex-1 min-h-[44px] max-h-[160px] border rounded-[16px] focus:outline-none resize-none overflow-y-auto ${aiInputText.length > AI_INPUT_MAX ? 'border-[var(--danger-color)]' : 'border-[var(--light-gray)] focus:border-[#FF9500]'}`}
                             disabled={isAiLoading}
+                            style={{ fieldSizing: 'content' } as React.CSSProperties}
                         />
                         <button onClick={() => submitAiChat()} disabled={isAiLoading || aiInputText.trim().length === 0 || aiInputText.length > AI_INPUT_MAX} className="w-[44px] h-[44px] rounded-full bg-[image:var(--ai-color)] text-white flex items-center justify-center cursor-pointer disabled:opacity-50">
                             <ArrowUpwardIcon className="!text-[16px]" />
@@ -295,7 +299,7 @@ export default function CreateQuestion() {
                     <Card className="max-w-[1000px] min-w-[400px]">
                         <div className="flex items-center justify-between py-[var(--spacing-16)]">
                             <div className="flex items-center gap-4">
-                                <StatusChip id={1} />
+                                <StatusChip name="回答募集中" />
                                 <h2 className="text-[length:var(--font-size-big)]">
                                     {titleText}
                                 </h2>


### PR DESCRIPTION
## 概要

AI サポートアシスタントの入力欄で改行が使えなかった問題を修正します。

## 変更内容

createQuestion.tsx の AI 入力欄を input[type=text] から textarea に変更しました。

- Shift+Enter で改行、Enter のみで送信（既存の挙動を維持）
- テキスト量に応じて入力欄の高さが自動伸長（最大 160px）
- textarea が伸びてもボタンが下揃えになるよう items-end に調整

## 確認方法

1. 質問作成画面で「AIに相談する」を開く
2. 入力欄で Shift+Enter を押して改行できることを確認
3. Enter のみで送信されることを確認
4. 長文入力時に入力欄が自動で縦に伸びることを確認