### PR TITLE
fix: タグを6個以上選択した際にエラーがでるように修正

### DIFF
--- a/frontend/app/components/createQuestion/TagSelector.tsx
+++ b/frontend/app/components/createQuestion/TagSelector.tsx
@@ -4,15 +4,31 @@ type TagSelectorProps = {
     selectedTagIds: string[];
     setSelectedTagIds: React.Dispatch<React.SetStateAction<string[]>>;
     allTagData: { id: string, name: string }[];
+    setErrors: React.Dispatch<React.SetStateAction<{ title?: string; detail?: string; tags?: string }>>;
 };
 
-export default function TagSelector({ selectedTagIds, setSelectedTagIds, allTagData }: TagSelectorProps) {
+export default function TagSelector({ selectedTagIds, setSelectedTagIds, allTagData, setErrors }: TagSelectorProps) {
 
     // タグの選択・解除をこれ1つで制御（トグル処理）
     const handleToggleSelect = (tagId: string) => {
-        setSelectedTagIds((prev) =>
-            prev.includes(tagId) ? prev.filter((id) => id !== tagId) : [...prev, tagId]
-        );
+        setSelectedTagIds((prev) => {
+            const isSelected = prev.includes(tagId);
+            if (!isSelected && prev.length >= 5) {
+                setErrors((current) => ({
+                    ...current,
+                    tags: "タグは最大5つまでしか選択できません。"
+                }));
+                return prev;
+            }
+            setErrors((current) => ({
+                ...current,
+                tags: undefined
+            }));
+
+            return isSelected 
+                ? prev.filter((id) => id !== tagId) 
+                : [...prev, tagId];
+        });
     };
 
     return (
@@ -21,16 +37,13 @@ export default function TagSelector({ selectedTagIds, setSelectedTagIds, allTagD
             {/* 上部：選択済みのタグを表示するエリア */}
             <div className={`p-[var(--spacing-8)] flex flex-wrap gap-[var(--spacing-8)] ${selectedTagIds.length === 0 ? 'h-[43px] items-center' : ''}`}>
                 {selectedTagIds.map(tagId => {
-                    // 1. findを使って該当するタグオブジェクトを1件取得
                     const currentTag = allTagData.find(tag => tag.id === tagId);
-
                     return (
                         <TagChip
                             key={tagId}
-                            // 安全のためにオプショナルチェーニング（?.）とフォールバックを設定
                             text={currentTag?.name || ""}
                             isButton={true}
-                            onClick={() => handleToggleSelect(tagId)} // ここも共通の関数で解除可能
+                            onClick={() => handleToggleSelect(tagId)}
                         />
                     );
                 })}
@@ -44,7 +57,6 @@ export default function TagSelector({ selectedTagIds, setSelectedTagIds, allTagD
 
             {/* 下部：選択可能なタグの一覧エリア */}
             <div className="p-[var(--spacing-16)] flex flex-wrap gap-x-[var(--spacing-8)] gap-y-[var(--spacing-12)]">
-                {/* 2. 修正：allTagData をそのまま map で回す */}
                 {allTagData.map(tag => {
                     const isSelected = selectedTagIds.includes(tag.id);
 
@@ -62,7 +74,6 @@ export default function TagSelector({ selectedTagIds, setSelectedTagIds, allTagD
                                 }
                             `}
                         >
-                            {/* 3. tag.name を直接描画できるのでシンプル */}
                             <span className="flex items-center h-[var(--spacing-12)]">{tag.name}</span>
                         </button>
                     );

--- a/frontend/app/routes/createQuestion.tsx
+++ b/frontend/app/routes/createQuestion.tsx
@@ -221,7 +221,7 @@ export default function CreateQuestion() {
                     <div className="flex flex-col gap-4 px-[var(--spacing-16)]">
                         {tagLoadError
                             ? <ErrorMessages message={tagLoadError} />
-                            : <TagSelector selectedTagIds={selectedTagIds} setSelectedTagIds={setSelectedTagIds} allTagData={allTags} />
+                            : <TagSelector selectedTagIds={selectedTagIds} setSelectedTagIds={setSelectedTagIds} allTagData={allTags} setErrors={setErrors}/>
                         }
                         {errors.tags && <ErrorMessages message={errors.tags} />}
                     </div>


### PR DESCRIPTION
# PR概要: 質問作成におけるタグ選択上限（最大5個）の即時ガードおよびリアルタイムエラー表示

## 📝 概要
質問作成画面（`CreateQuestion`）において、ユーザーがタグを6つ以上選択しようとした瞬間にその操作をブロック（無効化）し、同時に「タグは最大5つまでしか選択できません。」というエラーメッセージをリアルタイムに表示する機能を実装しました。

## 🔍 背景と課題
- **従来の挙動**: 画面下部の「内容確認」ボタンを押したタイミング（一括バリデーション実行時）ではじめて、タグが5個を超えているエラーが発覚する仕様でした。
- **発生していた課題**: ユーザーが上限を意識せずにタグを何個でも連打して選択できてしまうため、最後の確認ボタンを押すまでエラーに気づけず、手戻りが発生する不親切なUXになっていました。また、フロントエンドの内部State（配列）としても、一時的に6個以上のIDを保持できてしまう状態でした。

## 🛠️ 修正内容（アプローチ）
親コンポーネントのバリデーション用State更新関数（`setErrors`）を子コンポーネントへ渡し、**選択を試みたその瞬間**にガードをかける設計にアップデートしました。

1. **子コンポーネント（`TagSelector`）の拡張**:
   - Propsに `setErrors` を追加。
   - トグル処理（`handleToggleSelect`）の中で、現在未選択のタグを新しく追加しようとした際、すでに5つのタグが選ばれている場合は **Stateを更新せずに `return`（6つ目の選択を無効化）** するストッパーを配置。
   - 同時に、その場で `setErrors` を呼び出してタグに関するエラー文言をセット。
   - 逆に、正常に選択・解除が行われた場合は、自動的にタグのエラー表示をクリア（`undefined`化）する処理を追加。
2. **親コンポーネント（`CreateQuestion`）の連携**:
   - `<TagSelector>` の呼び出し時に `setErrors={setErrors}` を流し込むよう修正。

## ✨ 改善されたUX（ユーザー体験）
- ユーザーが6つ目のタグをクリックした瞬間に、ボタンの色は変わらず、画面上に赤文字で制限エラーが表示されるようになり、直感的で迷わない操作制限が実現しました。
- システム内部でも状態（配列の長さ）が絶対に5を超えることがなくなったため、データの安全性がより強固になりました。

## 🧪 テスト・確認事項
- [ ] タグを5つまで正常に選択・解除ができること。
- [ ] すでに5つ選択された状態で、未選択の6つ目のタグをクリックしたとき、選択されず（ボタンの色が変わらず）にエラーメッセージが即座に表示されること。
- [ ] 6つ目をブロックされた状態から、選択済みのタグを1つ解除した際、自動的にエラーメッセージが消えること。
- [ ] 5つ以内の状態で「内容確認」ボタンを押し、モーダルが正常に開くこと。