### PR TITLE
feat: 通知のすべて既読機能追加

### DIFF
--- a/frontend/app/api/notificationService.ts
+++ b/frontend/app/api/notificationService.ts
@@ -36,6 +36,10 @@ export const readNotification = async (notificationId:string): Promise<void> => 
     const response = await axiosClient.patch<void>(`/notifications/${notificationId}/read`);
 }
 
+export const allReadNotifications = async (): Promise<void> => {
+    const response = await axiosClient.patch<void>(`/notifications/read-all`);
+}
+
 const notificationService = {
     getNotifications,
 };

--- a/frontend/app/components/common/Notification.tsx
+++ b/frontend/app/components/common/Notification.tsx
@@ -1,3 +1,4 @@
+import { allReadNotifications } from "@/api/notificationService";
 import Card from "./Card";
 import type { NotificationItemProps } from "./NotificationItem";
 import NotificationItem from "./NotificationItem";
@@ -19,13 +20,23 @@ const calculateUnreadCount = (notifications: NotificationItemProps[]) => {
 }
 export default function Notification({ notifications }: NotificationProps) {
 
+    const handleAllRead = async () => {
+        const response = await allReadNotifications();
+    }
     return (
         <Card className="w-[400px] max-h-[400px] flex flex-col gap-2">
             <div className="flex justify-between border-b border-[var(--light-gray)] py-[var(--spacing-8)]">
                 <h2 className="text-[length:var(--font-size-big))]">通知</h2>
-                <p className="text-[var(--dark-gray)] flex items-center">
-                    {calculateUnreadCount(notifications)}件の未読
-                </p>
+
+                <div className="flex items-center gap-4">
+
+                    <p className="text-[var(--dark-gray)] flex items-center">
+                        {calculateUnreadCount(notifications)}件の未読
+                    </p>
+                    <p onClick={() => handleAllRead()} className="text-[var(--main-color)] cursor-pointer">
+                        すべて既読
+                    </p>
+                </div>
             </div>
             <ScrollBar>
                 {notifications.map((notification, i) => (


### PR DESCRIPTION
# PR概要: 通知の一括既読（すべて既読）機能の実装

## 📝 概要
溜まった未読通知を一括で既読状態にできる「すべて既読」機能を新しく実装しました。
APIリクエストの追加と、通知ドロップダウン（`Notification` コンポーネント）のヘッダーへの導線追加を行っています。

## 🔍 背景と課題
- **現状の課題**: 通知を既読にするには各通知を個別で処理（またはクリック）する必要があり、通知が大量に溜まった際にユーザーが一括で処理する手段がありませんでした。
- **改善アプローチ**: ユーザーの手間を減らしUXを向上させるため、ヘッダーの未読件数表示の横に「すべて既読」ボタンを配置し、1タップで全ての通知を既読化できるようにしました。

## 🛠️ 修正内容
画像（diff）の通り、API層とUI層にそれぞれ以下の修正を行っています。

### 1. API層 (`frontend/app/api/notificationService.ts`)
- 全通知を既読にするための `allReadNotifications` 関数を新規追加。
- バックエンドの `PATCH /notifications/read-all` エンドポイントを呼び出すように実装。

### 2. UI層 (`frontend/app/components/common/Notification.tsx`)
- 新設した `allReadNotifications` をインポートし、クリック時のハンドラー関数 `handleAllRead` を定義。
- 通知カード（`Card`）の上部ヘッダーのレイアウトを微調整し、未読件数表示の右隣に「すべて既読」テキストボタン（`cursor-pointer`）を配置。
- ボタンがクリックされた際に `handleAllRead()` が発動し、バックエンドへ既読化リクエストを送信するよう紐付け。

## 🧪 テスト・確認事項
- [ ] 通知ドロップダウンのヘッダー右側に「すべて既読」ボタンが正しく表示されていること。
- [ ] 未読通知が存在する状態で「すべて既読」をクリックした際、エラーが起きずにリクエストが送信されること。
- [ ] （Realtime等の通知更新ロジックと連動して）クリック後にヘッダーの未読バッジのカウントや、通知リストの未読表示がリアルタイムに消える（または既読表示に切り替わる）こと。