### PR TITLE
refactor: プロフィールの実績のところの文言を修正

### DIFF
--- a/frontend/app/routes/profile.tsx
+++ b/frontend/app/routes/profile.tsx
@@ -176,9 +176,9 @@ export default function Profile() {
                 {/* 実績数値グリッド */}
                 <div className="grid grid-cols-2 gap-4 shrink-0 pb-4">
                     {[
-                        { label: "質問回答数", value: profileData?.answerCount ?? 0 },
+                        { label: "回答投稿数", value: profileData?.answerCount ?? 0 },
                         { label: "ベストアンサー数", value: profileData?.bestAnswerCount ?? 0 },
-                        { label: "いいね総数", value: profileData?.totalLikeCount ?? 0 },
+                        { label: "いいね獲得数", value: profileData?.totalLikeCount ?? 0 },
                         { label: "質問数", value: profileData?.questionCount ?? 0 },
                     ].map((item, i) => (
                         <div key={i} className="border border-[var(--light-gray)] bg-white rounded-[16px] flex flex-col gap-2 items-center justify-center min-h-[100px]">


### PR DESCRIPTION
# PR概要: プロフィール画面の実績表示ラベルの文言改善（直感的な表現へのリファクタリング）

## 📝 概要
マイページ（プロフィール画面）の実績数値グリッドにおいて、ユーザーがデータの意味を直感的に正しく理解できるよう、表示ラベルの文言をリファクタリングしました。

## 🔍 背景と課題
従来の表記では、ユーザーが起こしたアクションや実績の対象について、以下のような解釈のブレ（誤解）が生じる可能性がありました。

1. **「質問回答数」**：自分が投稿した「質問に対する回答の数」なのか、自分が他の人の「質問に回答した数」なのかがボヤけていました。
2. **「いいね総数」**：自分がこれまでに「押したいいねの合計」なのか、他のユーザーから「もらったいいねの合計」なのかが曖昧でした。

これらの表記を、主客がハッキリとした100%誤解の起きない王道の言い回しに改善し、プロダクトの信頼感とUIの分かりやすさを向上させることを目的としています。

## 🛠️ 修正内容
`frontend/app/routes/profile.tsx` の実績数値グリッド（`label` 定義部分）を以下のように変更しました。

- **質問回答数 ➔ 『回答投稿数』**
  - 「投稿」というアクション名が明示されることで、自分が主体となって他のユーザーの質問に回答した実績数であることが完全にクリアになりました。
- **いいね総数 ➔ 『いいね獲得数』**
  - 「獲得」という言葉を組み合わせることで、他のユーザーから評価されて受け取った「もらったいいねの数」であることが一瞬で伝わるようになりました。

## 🧪 テスト・確認事項
- [ ] マイページ（`/profile`）にアクセスした際、実績グリッドの文言がそれぞれ「回答投稿数」「いいね獲得数」に正しく更新されていること。
- [ ] バックエンドから取得した数値（`answerCount`, `totalLikeCount`）が、新しいラベルの横に崩れることなく正常に表示されていること。
- [ ] 他の項目（「ベストアンサー数」「質問数」）の表示やレイアウトに影響が出ていないこと。