### PR TITLE
feat: 通知全件既読APIの実装

### DIFF
--- a/backend/src/routes/notification.ts
+++ b/backend/src/routes/notification.ts
@@ -62,4 +62,23 @@ router.patch('/:notificationId/read', requireAuth, async (req, res) => {
   return res.status(204).end();
 });
 
+// 全件既読
+// PATCH /api/v1/notifications/read-all
+router.patch('/read-all', requireAuth, async (req, res) => {
+  const userId = req.user!.id;
+
+  const { error } = await supabase
+    .from('notifications')
+    .update({ is_read: true })
+    .eq('receiver_user_id', userId)
+    .eq('is_read', false);
+
+  if (error) {
+    console.error('Supabase error updating notifications:', error);
+    return res.status(500).end();
+  }
+
+  return res.status(204).end();
+});
+
 export default router;


### PR DESCRIPTION
## 概要
未読の通知を全件既読にするAPIを実装する。

## 変更内容
- `PATCH /api/v1/notifications/read-all` エンドポイントを追加
- `requireAuth` ミドルウェアを追加
- 自分宛ての未読通知を全件 `is_read: true` に更新

## 関連イシュー
closes #164 

## 確認事項
- [ ] 自分宛ての未読通知が全件既読になる
- [ ] 未認証の場合は401が返る
- [ ] 成功時は204が返る