### PR TITLE
feat:検索条件クリアボタンを追加

### DIFF
--- a/frontend/app/routes/top.tsx
+++ b/frontend/app/routes/top.tsx
@@ -42,6 +42,13 @@ export default function Top() {
     const [searchWord, setSearchWord] = useState(""); // 入力中の文字列
     const [activeKeyword, setActiveKeyword] = useState("");
 
+    const handleFilterClear = () => {
+        setSelectedMyActionIds([])
+        setSelectedStatusIds([])
+        setSelectedTagIds([])
+        setSearchWord("")
+    }
+
     // 💡 修正: どんなリテラル型の配列ステートでも安全にトグルできるように型を抽象化
     const handleToggleId = <T extends string>(id: string, setIds: React.Dispatch<React.SetStateAction<T[]>>) => {
         setIds((prev) =>
@@ -110,7 +117,7 @@ export default function Top() {
                     setIsFilterOpen(true);
                 }
             }}>
-                <div className={`flex items-center justify-between border-b transition-all ${isFilterOpen ? "border-[var(--main-color)] mb-[var(--spacing16)]" : "border-transparent mb-0"}`}  onClick={()=> setIsFilterOpen(!isFilterOpen)}>
+                <div className={`flex items-center justify-between border-b transition-all ${isFilterOpen ? "border-[var(--main-color)] mb-[var(--spacing16)]" : "border-transparent mb-0"}`} onClick={() => setIsFilterOpen(!isFilterOpen)}>
                     <div className="flex items-center">
                         <FilterAltOutlinedIcon className="text-[var(--main-color)]" />
                         <p className="text-[length:var(--font-size-big)]">フィルター</p>
@@ -124,8 +131,9 @@ export default function Top() {
                         {/* マイアクション */}
                         <div className="flex flex-col gap-2">
                             <div className="py-[var(--spacing-8)]">
-                                <div className="border-b border-[var(--light-gray)] py-[var(--spacing-8)]">
+                                <div className="border-b border-[var(--light-gray)] py-[var(--spacing-8)] flex flex-row justify-between items-end">
                                     <p>マイアクション</p>
+                                    <button className="px-4 py-1 rounded-[4px] text-white bg-[var(--main-color)] shadow-[var(--box-shadow)] hover:shadow-[var(--hover-box-shadow)] transition-all duration-200 cursor-pointer active:shadow-none" onClick={() => handleFilterClear()}>条件クリア</button>
                                 </div>
                             </div>
                             <div className="flex gap-2 px-2">


### PR DESCRIPTION
# PR概要: 検索条件クリア（フィルターリセット）ボタンの追加

## 📝 概要
トップ画面（`frontend/app/routes/top.tsx`）のフィルター（マイアクション）セクションに、選択中のすべての検索条件を一括で初期化できる「条件クリア」ボタンを実装しました。

## 🔍 背景と課題
- **現状の課題**: ユーザーが複数のマイアクション、ステータス、タグ、検索ワードを掛け合わせて質問を絞り込んだ後、別の条件で再検索したい場合、すべてのチェックボックスや入力欄を1つずつ手動で解除・消去しなければならず、手間がかかっていました。
- **改善アプローチ**: 面倒なリセット操作を1タップで完結させ、検索体験の心地よさを向上させるために、一括クリアを行うボタンを設置しました。

## 🛠️ 修正内容
`frontend/app/routes/top.tsx` に対して、以下のロジックおよびUIの追加を行いました。

### 1. リセットロジックの追加
- すべての絞り込みState（マイアクション、ステータス、タグ、検索ワード）を一斉に空（初期状態）にする `handleFilterClear` 関数を新設。

### 2. UIの配置とレイアウト変更
- 「マイアクション」のヘッダー要素のレイアウトを `flex flex-row justify-between items-end` に変更し、タイトルの右隣に「条件クリア」ボタンを綺麗に配置。
- ボタンにはプロジェクト共通のメインカラー（`--main-color`）と影（`shadow`）を適用し、クリック時（`active:`）には影が消えるインタラクション（`active:shadow-none`）を設定。

## 🧪 テスト・確認事項
- [ ] 検索ワードを入力し、マイアクションやステータス、タグのチェックボックスをいくつか選択した状態で「条件クリア」ボタンをクリックした際、すべての選択・入力が同時に初期状態（空）に戻ること。
- [ ] 条件クリアボタンをクリックした直後、質問リストの絞り込みが即座に解除され、全件表示（または初期条件の表示）にリフレッシュされること。
- [ ] ボタンを押した瞬間に、影が消えるアクティブ時のスタイル（`active:shadow-none`）が意図通りに機能していること。