### PR TITLE
fix:通知パネルの「すべて既読」ボタンの表示制御と、実行前の確認ダイアログを追加

### DIFF
--- a/frontend/app/components/common/Notification.tsx
+++ b/frontend/app/components/common/Notification.tsx
@@ -19,9 +19,12 @@ const calculateUnreadCount = (notifications: NotificationItemProps[]) => {
     return count;
 }
 export default function Notification({ notifications }: NotificationProps) {
+    const unreadCount = calculateUnreadCount(notifications);
 
     const handleAllRead = async () => {
-        const response = await allReadNotifications();
+        const confirmed = window.confirm("全件既読にしますか？");
+        if (!confirmed) return;
+        await allReadNotifications();
     }
     return (
         <Card className="w-[400px] max-h-[400px] flex flex-col gap-2">
@@ -31,11 +34,13 @@ export default function Notification({ notifications }: NotificationProps) {
                 <div className="flex items-center gap-4">
 
                     <p className="text-[var(--dark-gray)] flex items-center">
-                        {calculateUnreadCount(notifications)}件の未読
+                        {unreadCount}件の未読
                     </p>
-                    <p onClick={() => handleAllRead()} className="text-[var(--main-color)] cursor-pointer">
-                        すべて既読
-                    </p>
+                    {unreadCount > 0 && (
+                        <p onClick={() => handleAllRead()} className="text-[var(--main-color)] cursor-pointer">
+                            すべて既読
+                        </p>
+                    )}
                 </div>
             </div>
             <ScrollBar>


### PR DESCRIPTION
## 概要

通知パネルの「すべて既読」ボタンの表示制御と、実行前の確認ダイアログを追加しました。

## 変更内容

- **「すべて既読」ボタンの表示条件を追加**
  未読通知が0件の場合はボタンを非表示にし、1件以上ある場合のみ表示するように変更しました。

- **全件既読の確認ダイアログを追加**
  「すべて既読」ボタンをクリックした際に「全件既読にしますか？」の確認ダイアログを表示するようにしました。キャンセルを選択した場合は処理を中断します。

## 変更ファイル

- `frontend/app/components/common/Notification.tsx`