### PR TITLE
style:質問詳細の改行・スクロール不具合修正およびプロフィールタグ表示の最適化

### DIFF
--- a/frontend/app/components/common/CardActionMenu.tsx
+++ b/frontend/app/components/common/CardActionMenu.tsx
@@ -37,7 +37,7 @@ export default function CardActionMenu({
 
                 {isDropDownOpen && (
                     <div
-                        className="transition-all hover:bg-[var(--hover-color)] cursor-pointer flex items-center justify-center bg-white rounded-[var(--spacing-4)] absolute left-0 translate-x-[-50%] shadow-[var(--box-shadow)] border border-[var(--light-gray)] w-[128px] h-[40px] z-10"
+                        className="transition-all hover:bg-[var(--hover-color)] cursor-pointer flex items-center justify-center bg-white rounded-[var(--spacing-4)] absolute left-[100%] translate-x-[-100%] shadow-[var(--box-shadow)] border border-[var(--light-gray)] w-[128px] h-[40px] z-10"
                         // onClick={handleRemove()} だとレンダリング時に即時実行されてしまうため、関数を渡す形に修正
                         onClick={handleRemoveClick}
                     >
@@ -52,12 +52,12 @@ export default function CardActionMenu({
             {/* 開閉トグル（矢印アイコン） */}
             {isOverflowing && (
                 isContentOpen ? (
-                    <KeyboardArrowDownOutlinedIcon
+                    <KeyboardArrowUpOutlinedIcon
                         className="cursor-pointer"
                         onClick={() => setIsContentOpen(false)}
                     />
                 ) : (
-                    <KeyboardArrowUpOutlinedIcon
+                    <KeyboardArrowDownOutlinedIcon
                         className="cursor-pointer"
                         onClick={() => setIsContentOpen(true)}
                     />

--- a/frontend/app/components/common/CollapsibleContent.tsx
+++ b/frontend/app/components/common/CollapsibleContent.tsx
@@ -1,5 +1,6 @@
 import { checkIsTextOverflowing } from "@/utils/textUtils";
 import { useEffect, useRef } from "react";
+
 type CollapsibleContentProps = {
     content: string;
     isContentOpen: boolean;
@@ -17,8 +18,17 @@ export default function CollapsibleContent({
 
     useEffect(() => {
         const checkLines = () => {
-            // utilsを使って、3行を超えているか(true/false)を取得
+            if (!textRef.current) return;
+
+            // 💡 修正点1: 判定の瞬間だけ maxHeight の制限を一時的に解除する
+            const originalMaxHeight = textRef.current.style.maxHeight;
+            textRef.current.style.maxHeight = "none";
+
+            // 制限がない本来のフルサイズ状態で、3行を超えているかを取得
             const overflowing = checkIsTextOverflowing(textRef.current, 3);
+
+            // 💡 修正点2: 判定が終わったら即座にスタイルを元に戻す（描画のガタつきは起きません）
+            textRef.current.style.maxHeight = originalMaxHeight;
 
             // 親コンポーネントに状態を通知
             setIsOverflowing(overflowing);
@@ -27,29 +37,32 @@ export default function CollapsibleContent({
             if (!overflowing) {
                 setIsContentOpen(true);
             } else if (!isContentOpen) {
-                // はじめてあふれた判定になった時は閉じておく（要件に合わせて調整可）
                 setIsContentOpen(false);
             }
         };
 
-        // 初回マウント時と content 変更時に実行
+        // 初回マウント時と状態変更時に実行
         checkLines();
 
         const handleResize = () => {
-            if (isContentOpen) return; // コンテンツが開いている場合は高さの再計算は不要
             checkLines();
         };
 
         window.addEventListener("resize", handleResize);
         return () => window.removeEventListener("resize", handleResize);
 
-    }, [content]); // contentが変更された時のみ高さを再計算する
+    }, [content, isContentOpen]);
 
     return (
         <div className="relative">
             <p
                 ref={textRef}
-                className={`px-[var(--spacing-16)] text-[length:var(--font-size-medium)] transition-all duration-300 ${!isContentOpen ? "max-h-[calc(3em*1.6+var(--spacing-16))] overflow-hidden" : ""}`}
+                className="!select-text whitespace-pre-wrap break-all px-[var(--spacing-16)] text-[length:var(--font-size-medium)] transition-all overflow-hidden"
+                style={{
+                    maxHeight: isContentOpen
+                        ? `${textRef.current?.scrollHeight ?? 1000}px` // 開いている時は実際の全高(px)
+                        : "calc(3em * 1.6 + var(--spacing-16))"       // 閉じている時は元の3行分の高さ
+                }}
             >
                 {content}{isContentOpen ? '' : '・・・'}
             </p>

--- a/frontend/app/components/common/Modal.tsx
+++ b/frontend/app/components/common/Modal.tsx
@@ -1,6 +1,6 @@
 import Card from "./Card";
-
 import CloseIcon from '@mui/icons-material/Close';
+import { useEffect } from "react"; // 💡 修正1: useEffect をインポート
 
 type ModalProps = {
     children: React.ReactNode;
@@ -8,11 +8,27 @@ type ModalProps = {
 }
 
 export default function Modal({ children, onClose }: ModalProps) {
+    
+    // 💡 修正2: 背景のスクロールを完全に止めるロジックを追加
+    useEffect(() => {
+        // 開いた時の元のスタイルを記憶しておく
+        const originalStyle = window.getComputedStyle(document.body).overflow;
+        
+        // 背景のスクロールを完全に禁止にする
+        document.body.style.overflow = "hidden";
+
+        // モーダルが閉じた時（アンマウント時）に、スクロールを元の状態に戻す
+        return () => {
+            document.body.style.overflow = originalStyle;
+        };
+    }, []); // 💡 初回表示時のみ実行
+
     const handleClose = () => {
         if (confirm("本当に閉じますか？")) {
             onClose();
         }
     }
+
     return (
         <div className="fixed inset-0 flex justify-center items-center z-[var(--z-modal)]">
 

--- a/frontend/app/routes/profile.tsx
+++ b/frontend/app/routes/profile.tsx
@@ -206,9 +206,9 @@ export default function Profile() {
             {/* ─── 3. よく回答しているタグ ─── */}
             <Card className="px-4 pt-0 flex flex-col gap-4 lg:order-3">
                 <SectionTitle title="よく回答しているタグ" />
-                <div className="flex-1 flex flex-col gap-4 min-h-[150px]">
+                <div className={`flex-1 flex flex-col ${topTags.length === 4 ? "justify-between" : "gap-5"} min-h-[150px]`}>
                     {topTags.length === 0 ? (
-                        <p className="text-sm text-[var(--dark-gray)] text-center py-4">データがありません</p>
+                        <p className="text-sm text-[var(--dark-gray)] text-center py-4 m-auto">データがありません</p>
                     ) : (
                         topTags.map((tag, index) => {
 

--- a/frontend/app/routes/question.tsx
+++ b/frontend/app/routes/question.tsx
@@ -86,7 +86,52 @@ function AnswererQuestionCard({ question }: AnswererQuestionCardProps) {
     </Card>
   );
 }
+type AnswererQuestionPreviewCardProps = {
+  question: QuestionDetail;
+};
+//回答作成時の質問プレビュー専用
+function AnswererQuestionPreviewCard({ question }: AnswererQuestionPreviewCardProps) {
+  return (
+    // 💡 修正1: Card 自体を縦方向の Flexbox（flex flex-col）にします。
+    // 外側から指定された高さを受け取れるよう、基本として h-full をつけておきます。
+    <Card className="w-full px-4 py-2 flex flex-col h-full">
 
+      {/* 💡 修正2: ヘッダーが潰れないように shrink-0 を指定 */}
+      <div className="flex items-center justify-between pb-[var(--spacing-16)] shrink-0">
+        <div className="flex items-center gap-4">
+          <StatusChip name={question.statusId} />
+          <h2 className="text-[length:var(--font-size-big)]">{question.title}</h2>
+        </div>
+      </div>
+
+      {/* 💡 修正3 【ここが最重要！】 */}
+      {/* flex-1 で残りの高さをすべてこのエリアに割り当て、min-h-0 で「中身の長さに引っ張られて親を突き破る現象」を完全に防ぎます */}
+      <div className='!select-text flex-1 min-h-0'>
+        {/* 💡 修正4: 上の div（flex-1）が確保した高さに100%フィットさせるため、max-h ではなく h-full にします */}
+        {/* 前回の改行・ローマ字対策（whitespace-pre-wrap break-all）も一緒に p タグへ仕込んであります */}
+        <ScrollBar className='h-full overflow-auto px-[var(--spacing-16)]'>
+          <p className="!select-text text-[length:var(--font-size-medium)] leading-relaxed whitespace-pre-wrap break-all">
+            {question.content}
+          </p>
+        </ScrollBar>
+      </div>
+
+      {/* 💡 修正5: フッターもヘッダー同様に潰れないよう shrink-0 を指定 */}
+      <div className="px-[var(--spacing-16)] py-[var(--spacing-8)] flex items-center justify-between shrink-0">
+        <div className="flex flex-wrap gap-2">
+          {question.tagNames?.map((tag, index) => (
+            <TagChip key={index} text={tag} />
+          ))}
+        </div>
+        <div className="flex items-center gap-2">
+          <Bookmark id={question.id} isBookmarked={question.isBookmarked ?? false} count={question.bookmarkCount} />
+          <Like id={question.id} type='question' isLiked={question.isLiked ?? false} count={question.likeCount} />
+          <Comment count={question.replyCount} />
+        </div>
+      </div>
+    </Card>
+  );
+}
 
 // ═════════════════════════════════════════
 // AnswerPreviewCard（回答返信モーダル内のプレビューカード）
@@ -103,11 +148,13 @@ function AnswerPreviewCard({ answer }: AnswerPreviewCardProps) {
         <p>{answer.userName}</p>
         <Time postingTime={answer.postingTime} />
       </div>
-      <p className="!select-text px-[var(--spacing-16)] text-[length:var(--font-size-medium)] leading-relaxed max-h-[120px] overflow-auto">
-        {answer.content}
-      </p>
+      <ScrollBar className='max-h-[100px] overflow-auto px-[var(--spacing-16)]'>
+        <p className="!select-text text-[length:var(--font-size-medium)] leading-relaxed ">
+          {answer.content}
+        </p>
+      </ScrollBar>
       <div className="flex justify-end mt-2">
-        <Like  id={answer.id} type='answer' count={answer.likeCount} isLiked={answer.isLiked} />
+        <Like id={answer.id} type='answer' count={answer.likeCount} isLiked={answer.isLiked} />
       </div>
     </Card>
   );
@@ -278,25 +325,34 @@ type AnswerFormProps = {
 
 function AnswerForm({ title, preview, content, onChange, error, isSubmitting, onSubmit }: AnswerFormProps) {
   return (
-    <div style={{ width: '750px', maxWidth: '90vw' }} className="sm:px-0 flex flex-col gap-[var(--spacing-8)] max-h-[80vh] overflow-y-auto">
-      <div className="pb-4 px-4 max-h-[240px] overflow-auto">
+    // 💡 画面全体の破綻を防ぐため、全体に bg-white と rounded を明示しています
+    <div style={{ width: '750px', maxWidth: '90vw' }} className="sm:px-0 flex flex-col max-h-[85vh] bg-white rounded-[var(--radius-big)] overflow-hidden">
+      
+      {/* 💡 【超重要】max-h から「h-[220px]」の固定値に変更し、shrink-0 を追加 */}
+      {/* これにより、カード側が「220pxの100%」を正しく認識して内部スクロールが100%発動し、下の要素の侵入も物理的に防ぎます */}
+      <div className="pt-4 px-4 h-[220px] shrink-0">
         {preview}
       </div>
-      <div className="flex flex-col gap-[var(--spacing-16)] px-4 pb-4 items-center">
-        <label className="w-full flex py-[var(--spacing-8)] justify-between items-center border-b border-[var(--main-color)]">
+      
+      {/* 💡 下半分の入力エリア：ここを flex-1 overflow-y-auto にすることで、ノートPCなどの狭い画面でもここだけが綺麗にスクロールして画面から溢れなくなります */}
+      <div className="flex flex-col gap-[var(--spacing-16)] px-4 pb-4 pt-2 items-center flex-1 overflow-y-auto">
+        <label className="w-full flex py-[var(--spacing-8)] justify-between items-center border-b border-[var(--main-color)] shrink-0">
           <p className="text-[length:var(--font-size-big)]">
             {title}
             <span className="text-[var(--danger-color)]">*</span>
           </p>
         </label>
+        
         <TextArea
           placeholder="例：setStateによる更新は非同期で行われるため、同じレンダーサイクル内では古い値を参照してしまうからです。"
           value={content}
           onChange={onChange}
           rows={5}
         />
+        
         {error && <ErrorMessages message={error} />}
-        <Button className='w-[344px]' onClick={onSubmit} text={isSubmitting ? '送信中...' : '回答送信'} disabled={isSubmitting} />
+        
+        <Button className='w-[344px] shrink-0' onClick={onSubmit} text={isSubmitting ? '送信中...' : '回答送信'} disabled={isSubmitting} />
       </div>
 
     </div>
@@ -558,7 +614,7 @@ export default function QuestionPage() {
         <Modal onClose={() => { setIsAnswerModalOpen(false); setAnswerContent(''); setAnswerError(''); }}>
           <AnswerForm
             title="回答を入力してください"
-            preview={<AnswererQuestionCard question={question} />}
+            preview={<AnswererQuestionPreviewCard question={question} />}
             content={answerContent}
             onChange={setAnswerContent}
             error={answerError}


### PR DESCRIPTION
# PR概要: UI/UXアクセシビリティの向上（プロフィールタグのレイアウト最適化、各種表示不具合・スクロール挙動の修正）

## 📝 概要
アプリ全体の表示品質と操作性（UX）を向上させるため、プロフィール画面のレイアウト最適化、質問詳細画面におけるテキスト折り返し・改行不具合の修正、モーダル周辺のスクロール挙動のクリーンアップなど、複数のUI/UX改善を行いました。

## 🔍 背景と課題
1. **よく回答しているタグ**: データ件数が少ない時（2〜3個）に不自然に広がったり、逆に綺麗に等間隔に並ばないなど、視覚的なバランスに課題がありました。
2. **質問本文の改行・折り返し**: 全てローマ字（半角英数字）の長文が入力された際に枠を突き抜けて文字が消えてしまう問題と、文章内の改行コード（`\n`）が半角スペースに化けてしまう問題が発生していました。
3. **回答作成モーダルのプレビュー**: 質問文の長さによってカードが高さを正しく計算できず、要素が重なったり不要なスクロールバーが表示されるなど、レイアウトが破綻していました。
4. **回答削除時の横スクロール**: 削除ボタンや周辺要素の配置・マージンの影響で、意図しない微小な横スクロールバーが出現していました。
5. **モーダルの背面スクロール**: モーダルが開いている最中も背景の画面がスクロールできてしまい、ユーザーが操作迷子になる原因になっていました。

## 🛠️ 修正内容

### 1. プロフィール画面: 「よく回答しているタグ」のレイアウト最適化
- 取得したタグの件数（`topTags.length`）に応じてスタイルを動的に分岐。
- 4つの時は全体の高さいっぱいに綺麗に広がり（`justify-between`）、3つ以下の時は同じ間隔をキープしたまま美しく上詰め（`justify-start gap-5`）で配置されるように調整しました。

### 2. 質問詳細画面: テキスト表示の不具合修正
- 本文コンポーネントの `<p>` タグに **`break-all`** と **`whitespace-pre-wrap`** を適用。
- 長文の英数字連打でも必ず枠内で自動折り返しされ、かつ文章内の本来の改行が100%画面に反映されるように修正しました。

### 3. 回答作成モーダル: プレビューエリアの高さ固定とガード
- プレビューを包む親要素の `max-height` を **`h-[220px]`** の固定値へ変更し、さらに **`shrink-0`** を付与。
- カード側が正確な高さを認識できるようになり、カード内部のスクロールバーが正しく駆動するよう変更しました（要素の重なりや無駄な二重スクロールを解消）。

### 4. 回答削除コンポーネント: 横スクロールバーの排除
- 削除ボタン、あるいは削除確認エリアの配置スタイルを微調整し、コンテナの幅（`w-full`）を圧迫して発生していた不要な横スクロールバーを削除しました。

### 5. 共通Modalコンポーネント: 背景（Body）のスクロールロック実装
- `Modal` 内に `useEffect` を導入し、モーダルマウント時に `document.body.style.overflow = "hidden"` を適用。
- アンマウント（閉じる時）には自動で元のスタイルに復元（クリーンアップ）するロジックを実装し、背面のコンテンツがスクロールされるのを完全に防ぎました。

## 🧪 テスト・確認事項
- [ ] **プロフィール**: タグが2個、3個、4個のそれぞれのパターンで、上から詰まった綺麗な等間隔で並んでいること。
- [ ] **質問詳細（改行）**: ローマ字だけの長文や、改行が多い文章が意図通り折り返され、正しく改行されて表示されること。
- [ ] **回答モーダル**: 非常に長い質問をプレビューした際、プレビュー枠内（220px）だけで綺麗にスクロールし、下のTextAreaや送信ボタンに被らないこと。
- [ ] **回答削除**: 回答削除のアクション時に、画面の右端や下部に余計な横スクロールバーが発生しないこと。
- [ ] **背面スクロール**: モーダル（回答作成など）を開いている間、マウスホイールやスワイプをしても後ろの画面が完全にロックされて動かないこと。モーダルを閉じたらスクロールが再開すること。