### PR TITLE
style: rechartsで作成した棒グラフ要素をクリックすると黒いborderが出てしまう不具合を修正

### DIFF
--- a/frontend/app/index.css
+++ b/frontend/app/index.css
@@ -57,6 +57,13 @@ html {
     user-select: none;
 }
 
+.recharts-wrapper:focus,
+.recharts-surface:focus {
+    outline: none !important;
+}
+.recharts-wrapper *:focus {
+    outline: none !important;
+}
 body {
     font-family: "Noto Sans JP", sans-serif;
     color: var(--text-color-black);


### PR DESCRIPTION
# PR概要: Rechartsグラフコンポーネントにおけるクリック時の黒い枠線（フォーカスアウトライン）の抑制

## 📝 概要
プロフィール画面等の実績グラフ（Recharts）において、グラフエリアや内部の棒グラフ要素（Bar）をクリックした際に、ブラウザのデフォルト挙動として表示されてしまう意図しない黒い枠線（`outline`）をCSS側で完全に非表示化しました。

## 🔍 背景と課題
- **現状の課題**: Rechartsはアクセシビリティ（キーボード操作等）への配慮から、グラフ全体のラッパー要素や、内部の各種SVG要素（棒グラフの矩形、軸、凡例など）にフォーカスが当たる仕様になっています。
- **発生していた問題**: これにより、ユーザーが普通にマウスやタップで棒グラフをクリックした際にも、要素の周りに太い黒枠（フォーカス時のアウトライン）が出現してしまい、プロダクト全体の洗練されたUI/UXを損ねていました。外側のラッパー要素の枠線を消すだけでは不十分で、グラフ内部の細かい子要素をクリックした際にも同様の現象が発生していました。

## 🛠️ 修正内容
グローバルCSSファイル（`frontend/app/index.css`）に、Rechartsのフォーカス制御を行う以下のスタイルを追加しました。

1. **全体・コンテナの制御**
   `.recharts-wrapper:focus` および `.recharts-surface:focus` に対して `outline: none !important;` を指定し、グラフの外枠全体に枠線が出ないようにガード。
2. **内部要素（子要素）の包括的制御**
   `.recharts-wrapper *:focus` を追加。これにより、グラフ内部に自動生成されるすべてのSVG要素（棒グラフの棒やテキストなど）にフォーカスが当たった際のアウトラインも強制的に無効化し、どの部分をクリックしても黒枠が出現しないように徹底しました。

## 🧪 テスト・確認事項
- [ ] 実績画面等の棒グラフが表示されているページへアクセスする。
- [ ] グラフの背景部分、目盛りテキスト部分、および棒グラフの「棒」そのものを複数回クリック・連打し、画面上に不自然な黒い枠線（ボーダー）が一切出現しないことを確認。
- [ ] グラフ周辺のレイアウトや、他の要素（テキストカラーやフォントなど）のスタイルに意図しない影響が出ていないことを確認。