### PR TITLE
style: ローマ字などで改行されずにスタイルが崩れる不具合を修正

### DIFF
--- a/frontend/app/index.css
+++ b/frontend/app/index.css
@@ -55,6 +55,8 @@ html {
     font-size: 16px;
     line-height: 1.6;
     user-select: none;
+    word-break: break-all;
+    white-space: pre-wrap;
 }
 
 body {


### PR DESCRIPTION
# PR概要: アプリ全体におけるテキスト折り返しおよび改行コード反映のグローバル対応

## 📝 概要
長文のローマ字（半角英数字の羅列）が入力された際に自動折り返しされずにレイアウトが崩れてしまう問題、および文章内の改行コード（`\n`）が画面上で半角スペースに化けてしまう問題を解決するため、グローバルCSSにてアプリ全体のデフォルト挙動を修正しました。

## 🔍 背景と課題
- **現状の課題**: ユーザーがスペースを含まない長文のローマ字（URLや半角英数字の連続、英単語の長文など）を入力した際、CSSのデフォルト仕様により「1つの長い単語」と認識され、右側の枠線を突き抜けてレイアウトが崩れる、あるいは隠れてしまう不具合が発生していました。
- **改行コードの仕様**: テキスト内の改行（`\n`）もHTML上では1つの半角スペースに集約されてしまうため、意図した改行が反映されていませんでした。
- **アプローチ**: コンポーネント個別にクラス（`break-all` や `whitespace-pre-wrap`）を付与するのではなく、最上位の `html` タグに対して共通のスタイルを設定することで、アプリ全体のすべてのテキスト表示において一括してこの脆弱性を排除し、安全性を担保しました。

## 🛠️ 修正内容
グローバルCSSファイル（`frontend/app/index.css`）の `html` セレクタに対し、以下のCSSプロパティを追加しました。

```css
html {
    /* ...既存のスタイル... */
    word-break: break-all;     /* 枠線の右端に到達した際、単語の途中でも強制的に折り返す */
    white-space: pre-wrap;     /* 改行コード（\n）を本物の改行として扱い、かつ右端での自動折り返しも有効にする */
}