### PR TITLE
style: マイアクションの選択肢が横幅を狭めた際に要素ごと改行されない不具合を修正

### DIFF
--- a/frontend/app/routes/top.tsx
+++ b/frontend/app/routes/top.tsx
@@ -139,7 +139,7 @@ export default function Top() {
                                     <button className="px-4 py-1 rounded-[4px] text-white bg-[var(--main-color)] shadow-[var(--box-shadow)] hover:shadow-[var(--hover-box-shadow)] transition-all duration-200 cursor-pointer active:shadow-none" onClick={() => handleFilterClear()}>条件クリア</button>
                                 </div>
                             </div>
-                            <div className="flex gap-2 px-2">
+                            <div className="flex gap-2 px-2 flex-wrap">
                                 {MY_ACTIONS.map((myAction) => (
                                     <FilterChip
                                         key={myAction.id}


### PR DESCRIPTION
# PR概要: レスポンシブ時におけるマイアクション選択肢（フィルターチップ）の自動折り返し対応

## 📝 概要
トップ画面（`frontend/app/routes/top.tsx`）のフィルターセクションにおいて、画面の横幅が狭くなった際にマイアクションの選択肢（チップ）が要素ごと綺麗に改行（折り返し）されるよう、レイアウトスタイルを修正しました。

## 🔍 背景と課題
- **現状の課題**: マイアクションの選択肢を並べている親コンテナが `flex`（標準では折り返しなしの `flex-nowrap`）になっていたため、スマートフォンなどの端末で閲覧したり、ブラウザの横幅を狭めたりした際に、チップが画面右外へはみ出してしまう、あるいは不自然に潰れてしまう表示崩れが発生していました。
- **改善アプローチ**: 要素がコンテナの幅に収まりきらなくなった場合に、自動的に2行目、3行目へと要素単位で綺麗に回り込むようにスタイルを調整し、レスポンシブ対応を強化しました。

## 🛠️ 修正内容
`frontend/app/routes/top.tsx` のマイアクション要素をループ展開（`.map`）している親の `div` タグに対して、以下の変更を行いました。

- **修正前**: `<div className="flex gap-2 px-2">`
- **修正後**: `<div className="flex gap-2 px-2 flex-wrap">`
  - Tailwind CSS の **`flex-wrap`** クラスを追加したことで、子要素の `FilterChip` が親の横幅を超えた際に自動で改行されるようになりました。

## 🧪 テスト・確認事項
- [ ] トップ画面のフィルターを開き、マイアクションの選択肢（チップ）が表示されていることを確認。
- [ ] ブラウザの検証ツール等で画面幅をスマートフォンサイズ（例: iPhone SE等の375px幅）まで狭めた際、チップが右側にはみ出さず、要素の区切りで綺麗に2行目以降に折り返されて表示されること。
- [ ] 各チップ間の余白（`gap-2`）やクリック時の挙動が、今回の修正後も変わらず正常に機能していること。