### PR TITLE
style: コンフリクトで消してしまった修正を追加

### DIFF
--- a/frontend/app/routes/profile.tsx
+++ b/frontend/app/routes/profile.tsx
@@ -216,9 +216,9 @@ export default function Profile() {
             <Card className="px-4 pt-0 flex flex-col gap-4 lg:order-3">
                 <SectionTitle title="よく回答しているタグ" />
                 {isLoading ? <Loading /> :
-                    <div className="flex-1 flex flex-col gap-4 min-h-[150px]">
+                    <div className={`flex-1 flex flex-col ${topTags.length === 4 ? "justify-between" : "gap-5"} min-h-[150px]`}>
                         {topTags.length === 0 ? (
-                            <p className="text-sm text-[var(--dark-gray)] text-center py-4">データがありません</p>
+                            <p className="text-sm text-[var(--dark-gray)] text-center py-4 m-auto">データがありません</p>
                         ) : (
                             topTags.map((tag, index) => {
 


### PR DESCRIPTION
# PR概要: コンフリクトにより消失していたプロフィール画面「よく回答しているタグ」のレイアウト修正の再適用

## 📝 概要
他ブランチとのマージ・リベースの際に、コンフリクトによって一時的に消失（先祖返り）してしまっていた、プロフィール画面（`frontend/app/routes/profile.tsx`）の「よく回答しているタグ」セクションのレイアウト最適化ロジックを再度適用しました。

## 🔍 背景と経緯
- 以前、タグの取得件数（2〜4個）に応じて縦幅を綺麗に等間隔、あるいは上詰めに配置するスタイル修正、およびデータなし時の文言位置の調整（`m-auto`）を実装していました。
- しかし、直近のコンフリクト解消の過程で当該コードが誤って以前の古い記述（固定の `gap-4` ）に上書きされてしまっていたため、正しい最新のロジックへと復元しました。

## 🛠️ 修正内容
`frontend/app/routes/profile.tsx` の「よく回答しているタグ」コンテナおよびデータなし時の文言に対して、以下の修正を再適用しました。

1. **タグ件数に応じた動的スタイルの復元**
   - 固定の `gap-4` を撤廃し、件数に応じた分岐を再導入。
   - 4つの時は全体の高さいっぱいに広がり（`justify-between`）、3つ以下の時は同じ間隔をキープしたまま美しく上詰め（`gap-5`）で配置されるように修正。
2. **データなし時の表示位置ガードの復元**
   - タグが0件の際の「データがありません」というメッセージ要素に対し、中央にジャストフィットさせるための **`m-auto`** クラスを再付与。

## 🧪 テスト・確認事項
- [ ] プロフィール画面（`/profile`）において、よく回答しているタグの数が3個以下の時と、4個の時でそれぞれのレイアウト（上詰め / いっぱいに広がる）が意図通り切り替わること。
- [ ] タグのデータが0件の際、「データがありません」というテキストがカード内の垂直・水平方向の中央（ど真ん中）に綺麗に配置されること。