### PR TITLE
fix: 質問投稿確認モーダルのサイズ・UIを他のモーダルと統一

### DIFF
--- a/frontend/app/components/common/Modal.tsx
+++ b/frontend/app/components/common/Modal.tsx
@@ -18,7 +18,7 @@ export default function Modal({ children, onClose }: ModalProps) {
 
             <div className="absolute inset-0 bg-[var(--light-gray)] opacity-50" onClick={() => handleClose()}></div>
 
-            <Card className="!bg-[var(--base-color)] z-[2] relative !p-[var(--spacing-32)] gap-[var(--spacing-32)] flex flex-col justify-center items-center">
+            <Card className="!bg-[var(--base-color)] z-[2] relative !p-[var(--spacing-32)] gap-[var(--spacing-32)] flex flex-col justify-center items-center w-[750px] max-w-[90vw]">
                 <button className="bg-[var(--danger-color)] text-white rounded-full w-[50px] h-[50px] absolute top-0 right-0 transform translate-x-1/2 -translate-y-1/2 flex items-center justify-center cursor-pointer" onClick={() => handleClose()}>
                     <CloseIcon />
                 </button>

--- a/frontend/app/routes/createQuestion.tsx
+++ b/frontend/app/routes/createQuestion.tsx
@@ -295,33 +295,38 @@ export default function CreateQuestion() {
 
             {isModalOpen && (
                 <Modal onClose={() => setIsModalOpen(false)}>
-                    <Card className="max-w-[1000px] min-w-[400px]">
-                        <div className="flex items-center justify-between py-[var(--spacing-16)]">
-                            <div className="flex items-center gap-4">
-                                <StatusChip name="回答募集中" />
-                                <h2 className="text-[length:var(--font-size-big)]">
-                                    {titleText}
-                                </h2>
-                            </div>
+                    <div style={{ width: '750px', maxWidth: '90vw' }} className="flex flex-col gap-[var(--spacing-8)] max-h-[80vh]">
+                        <div className="px-4">
+                            <Card>
+                                <div className="flex items-center justify-between py-[var(--spacing-16)]">
+                                    <div className="flex items-center gap-4">
+                                        <StatusChip name="回答募集中" />
+                                        <h2 className="text-[length:var(--font-size-big)]">
+                                            {titleText}
+                                        </h2>
+                                    </div>
+                                </div>
+                                <div className="px-[var(--spacing-16)] py-[var(--spacing-8)]">
+                                    <ScrollBar className="min-h-[150px] max-h-[300px]">
+                                        <p className="whitespace-pre-wrap break-words">{detailText}</p>
+                                    </ScrollBar>
+                                </div>
+                                <div className="px-[var(--spacing-16)] py-[var(--spacing-8)] flex items-center justify-between">
+                                    <div className="flex flex-wrap gap-2">
+                                        {selectedTagIds.map((tagId, index) => (
+                                            <TagChip key={index} text={allTags.find((t) => t.id === tagId)?.name ?? tagId} />
+                                        ))}
+                                    </div>
+                                </div>
+                            </Card>
                         </div>
-
-                        <div className="px-[var(--spacing-16)] py-[var(--spacing-8)]">
-                            <ScrollBar className="max-h-[300px]">
-                                <p className="whitespace-pre-wrap break-words">{detailText}</p>
-                            </ScrollBar>
+                        <div className="flex justify-center pb-4 shrink-0">
+                            <Button
+                                onClick={() => submitQuestion()}
+                                text={isSubmitting ? "投稿中..." : "質問投稿"}
+                            />
                         </div>
-                        <div className="px-[var(--spacing-16)] py-[var(--spacing-8)] flex items-center justify-between">
-                            <div className="flex flex-wrap gap-2">
-                                {selectedTagIds.map((tagId, index) => (
-                                    <TagChip key={index} text={allTags.find((t) => t.id === tagId)?.name ?? tagId} />
-                                ))}
-                            </div>
-                        </div>
-                    </Card>
-                    <Button
-                        onClick={() => submitQuestion()}
-                        text={isSubmitting ? "投稿中..." : "質問投稿"}
-                    />
+                    </div>
                 </Modal>
             )}
         </div>


### PR DESCRIPTION
  frontend/app/components/common/Modal.tsx
  - w-[750px] max-w-[90vw] を追加し、全モーダルの横幅を750pxに統一

   frontend/app/routes/createQuestion.tsx
  - モーダル内容を style={{ width: '750px', maxWidth: '90vw' }} の wrapper div で囲み横幅を統一
  - max-h-[80vh] で縦幅を統一
  - ScrollBar を min-h-[150px] max-h-[300px] に変更（文字量に応じたスクロール制御）
  - タイトル・タグ・投稿ボタンを固定表示に変更
  - 不要な Card の import を削除し再追加