### PR TITLE
style: 質問詳細画面のモーダル時プレビューで×ボタンが画面上部にはみ出ているのを修正

### DIFF
--- a/frontend/app/components/common/Modal.tsx
+++ b/frontend/app/components/common/Modal.tsx
@@ -34,7 +34,7 @@ export default function Modal({ children, onClose }: ModalProps) {
 
             <div className="absolute inset-0 bg-[var(--light-gray)] opacity-50" onClick={() => handleClose()}></div>
 
-            <Card className="!bg-[var(--base-color)] z-[2] relative !p-[var(--spacing-32)] gap-[var(--spacing-32)] flex flex-col justify-center items-center">
+            <Card className="!bg-[var(--base-color)] z-[2] relative !p-[var(--spacing-16)] gap-[var(--spacing-32)] flex flex-col justify-center items-center">
                 <button className="bg-[var(--danger-color)] text-white rounded-full w-[50px] h-[50px] absolute top-0 right-0 transform translate-x-1/2 -translate-y-1/2 flex items-center justify-center cursor-pointer" onClick={() => handleClose()}>
                     <CloseIcon />
                 </button>

--- a/frontend/app/routes/question.tsx
+++ b/frontend/app/routes/question.tsx
@@ -142,7 +142,7 @@ function AnswerPreviewCard({ answer }: AnswerPreviewCardProps) {
         <p>{answer.userName}</p>
         <Time postingTime={answer.postingTime} />
       </div>
-      <ScrollBar className='max-h-[100px] overflow-auto px-[var(--spacing-16)]'>
+      <ScrollBar className='max-h-[64px] overflow-auto px-[var(--spacing-16)]'>
         <p className="!select-text text-[length:var(--font-size-medium)] leading-relaxed ">
           {answer.content}
         </p>
@@ -319,8 +319,8 @@ type AnswerFormProps = {
 
 function AnswerForm({ title, preview, content, onChange, error, isSubmitting, onSubmit }: AnswerFormProps) {
   return (
-    <div style={{ width: '750px', maxWidth: '90vw' }} className="sm:px-0 flex flex-col max-h-[85vh] bg-white rounded-[var(--radius-big)] overflow-hidden">
-      <div className="pt-4 px-4 h-[220px] shrink-0">
+    <div style={{ width: '750px', maxWidth: '90vw' }} className="sm:px-0 flex flex-col max-h-[85vh] rounded-[var(--radius-big)] overflow-hidden">
+      <div className="pt-4 px-4 max-h-[220px] shrink-0">
         {preview}
       </div>
       <div className="flex flex-col gap-[var(--spacing-16)] px-4 pb-4 pt-2 items-center flex-1 overflow-y-auto">


### PR DESCRIPTION
# PR概要: モーダル表示時における閉じる（×）ボタンの画面上部はみ出し不具合の修正

## 📝 概要
質問詳細画面（`question.tsx`）から開くモーダルにおいて、コンテンツの縦幅が大きすぎるためにモーダル右上の「閉じる（×）ボタン」が画面上部（ビューポート外）へはみ出してしまい、操作できなくなる表示不具合を修正しました。

## 🔍 背景と課題
- **現状の課題**: `Modal` コンポーネントの内余白（Padding）が広く、かつ回答プレビューエリアが固定の高さ（`h-[220px]`）を確保していたため、ノートPCなどの縦幅が狭い画面（低解像度ブラウザ）で表示した際に、モーダル全体が上に押し上げられていました。
- **発生していた問題**: これにより、モーダルの右上に絶対配置（`absolute`）されている閉じるボタン（`CloseIcon`）が画面上端を突き抜けて見えなくなったり、クリックしづらくなったりするUX上の問題が発生していました。
- **改善アプローチ**: モーダルの不要な余白を削り、プレビュー領域の中身の量に応じて柔軟に縮むようにスタイルをタイトに調整することで、ボタンが必ず画面内に収まるようにレイアウトを最適化しました。

## 🛠️ 修正内容

### 1. 共通Modalコンポーネントの余白スリム化（`Modal.tsx`）
- モーダル枠となる `Card` の内余白を **`!p-[var(--spacing-32)]` から `!p-[var(--spacing-16)]`** へ変更。
- 上下の不要なデッドスペースを削ることで、モーダル全体の重心を下げ、ボタン位置を画面内に引き戻しました。

### 2. 回答プレビューカードの最大高制限の縮小（`question.tsx`）
- `AnswerPreviewCard` 内にある `ScrollBar` の最大高を **`max-h-[100px]` から `max-h-[64px]`** へ縮小。
- テキストが長い場合でもプレビュー自体が縦に伸びすぎないように制限を強化しました。

### 3. モーダル内プレビューコンテナの可変高化（`question.tsx`）
- `AnswerForm` 内のプレビュー領域を包む `div` の高さを、固定値の **`h-[220px]` から最大高の `max-h-[220px]`** へ変更。
- プレビューする内容が短い（文字数が少ない）場合に、無駄な高さが確保されて全体が引き伸ばされるのを防ぎ、中身にジャストフィットする形に修正しました。

## 🧪 テスト・確認事項
- [ ] 質問詳細画面で回答作成モーダル、または該当のプレビューを伴うモーダルを開く。
- [ ] プレビューの中身（回答内容）が短い場合と長い場合の両方において、モーダル全体の縦幅がコンパクトに収まっていることを確認。
- [ ] ブラウザの縦