### PR TITLE
style: 質問作成画面のモーダルを質問詳細のモーダルと同様のスタイルに修正

### DIFF
--- a/frontend/app/routes/createQuestion.tsx
+++ b/frontend/app/routes/createQuestion.tsx
@@ -221,7 +221,7 @@ export default function CreateQuestion() {
                     <div className="flex flex-col gap-4 px-[var(--spacing-16)]">
                         {tagLoadError
                             ? <ErrorMessages message={tagLoadError} />
-                            : <TagSelector selectedTagIds={selectedTagIds} setSelectedTagIds={setSelectedTagIds} allTagData={allTags} setErrors={setErrors}/>
+                            : <TagSelector selectedTagIds={selectedTagIds} setSelectedTagIds={setSelectedTagIds} allTagData={allTags} setErrors={setErrors} />
                         }
                         {errors.tags && <ErrorMessages message={errors.tags} />}
                     </div>
@@ -295,33 +295,38 @@ export default function CreateQuestion() {
 
             {isModalOpen && (
                 <Modal onClose={() => setIsModalOpen(false)}>
-                    <Card className="max-w-[1000px] min-w-[400px]">
-                        <div className="flex items-center justify-between py-[var(--spacing-16)]">
-                            <div className="flex items-center gap-4">
-                                <StatusChip name="回答募集中" />
-                                <h2 className="text-[length:var(--font-size-big)]">
-                                    {titleText}
-                                </h2>
+                    <div style={{ width: '750px', maxWidth: '90vw' }} className="p-4 gap-4 sm:px-0 flex flex-col max-h-[85vh] rounded-[var(--radius-big)] overflow-hidden">
+                        <Card className="max-w-[1000px] min-w-[400px]">
+                            <div className="flex items-center justify-between py-[var(--spacing-16)]">
+                                <div className="flex items-center gap-4">
+                                    <StatusChip name="回答募集中" />
+                                    <h2 className="text-[length:var(--font-size-big)]">
+                                        {titleText}
+                                    </h2>
+                                </div>
                             </div>
-                        </div>
 
-                        <div className="px-[var(--spacing-16)] py-[var(--spacing-8)]">
-                            <ScrollBar className="max-h-[300px]">
-                                <p className="whitespace-pre-wrap break-words">{detailText}</p>
-                            </ScrollBar>
-                        </div>
-                        <div className="px-[var(--spacing-16)] py-[var(--spacing-8)] flex items-center justify-between">
-                            <div className="flex flex-wrap gap-2">
-                                {selectedTagIds.map((tagId, index) => (
-                                    <TagChip key={index} text={allTags.find((t) => t.id === tagId)?.name ?? tagId} />
-                                ))}
+                            <div className="px-[var(--spacing-16)] py-[var(--spacing-8)]">
+                                <ScrollBar className="max-h-[64px]">
+                                    <p className="whitespace-pre-wrap break-words">{detailText}</p>
+                                </ScrollBar>
                             </div>
+                            <div className="px-[var(--spacing-16)] py-[var(--spacing-8)] flex items-center justify-between">
+                                <div className="flex flex-wrap gap-2">
+                                    {selectedTagIds.map((tagId, index) => (
+                                        <TagChip key={index} text={allTags.find((t) => t.id === tagId)?.name ?? tagId} />
+                                    ))}
+                                </div>
+                            </div>
+                        </Card>
+                        <div className="w-full flex justify-center">
+                            <Button
+                                onClick={() => submitQuestion()}
+                                text={isSubmitting ? "投稿中..." : "質問投稿"}
+                                className="w-[344px]"
+                            />
                         </div>
-                    </Card>
-                    <Button
-                        onClick={() => submitQuestion()}
-                        text={isSubmitting ? "投稿中..." : "質問投稿"}
-                    />
+                    </div>
                 </Modal>
             )}
         </div>


### PR DESCRIPTION
# PR概要: 質問作成画面におけるプレビューモーダルのスタイル共通化・レイアウト最適化

## 📝 概要
質問作成画面（`createQuestion.tsx`）の投稿前確認モーダルにおいて、質問詳細画面側の回答作成モーダルで適用した「画面サイズに安全にフィットする最新のレイアウトスタイル」と同様の設計へと修正し、デザインおよびスクロール挙動の一貫性を高めました。

## 🔍 背景と課題
- **現状の課題**: 質問作成時の確認モーダルは、以前の古いモーダル構造（高さや幅の制限が甘く、コンテンツ量によって縦長に伸びやすい設計）のままになっていました。
- **発生していた問題**: 質問本文（詳細）が長文の場合に、モーダル全体が縦に伸びすぎてしまい、下部にある「質問投稿」ボタンが画面外に押し出されたり、右上の閉じるボタンの配置バランスが崩れる危険性がありました。
- **改善アプローチ**: 先の修正で確立した「幅750px固定 / 最大高85vh / 内部領域のタイトなスクロール制限」というモーダル設計をこちらにも水平展開し、アプリ全体で共通のモーダルUXを提供できるように統一しました。

## 🛠️ 修正内容
`frontend/app/routes/createQuestion.tsx` 内の `isModalOpen` 時に展開されるモーダル内コンポーネント構造を一新しました。

1. **モーダル最外殻のラッパー要素の追加と制限設定**
   - 新たに最外殻の `div` に対して `style={{ width: '750px', maxWidth: '90vw' }}` および `max-h-[85vh] rounded-[var(--radius-big)] overflow-hidden` を付与。
   - どんな解像度のディスプレイでも、モーダル本体が画面からはみ出さない基盤を整えました。

2. **プレビュー本文のスクロール上限の厳格化**
   - 質問内容を表示する `ScrollBar` の最大高を **`max-h-[300px]` から `max-h-[64px]`** へと縮小。
   - テキストのボリュームに左右されず、確認用プレビューをコンパクトに収めるようにしました。

3. **アクションボタン（質問投稿）の配置最適化**
   - 構造を整理し、プレビューカードの下部に「質問投稿」ボタン（`w-[344px]`）が常に中央揃えで、押し出されることなく定位置に美しく鎮座するレイアウトへ修正しました。

## 🧪 テスト・確認事項
- [ ] 質問作成画面（`/questions/create`等）で、タイトル・カテゴリ・本文を入力してプレビューモーダルを開く。
- [ ] 表示されたモーダルが、質問詳細画面で表示される回答モーダルと全く同じ横幅（750pxベース）・角丸・余白感で統一感を持って表示されること。
- [ ] 入力した本文が非常に長い場合でも、プレビュー領域（`max-h-[64px]`）の枠内だけで綺麗にスクロールし、下部の「質問投稿」ボタンが画面外に消えずに押しやすい位置に固定されていること。