### PR TITLE
style: 質問本文が長いとテキストがあふれてしまうのを修正

### DIFF
--- a/frontend/app/routes/question.tsx
+++ b/frontend/app/routes/question.tsx
@@ -95,7 +95,7 @@ type AnswererQuestionPreviewCardProps = {
 //回答作成時の質問プレビュー専用
 function AnswererQuestionPreviewCard({ question }: AnswererQuestionPreviewCardProps) {
   return (
-    <Card className="w-full px-4 py-2 flex flex-col h-full">
+    <Card className="w-full px-4 py-2 flex flex-col h-full max-h-[200px] overflow-hidden">
       <div className="flex items-center justify-between pb-[var(--spacing-16)] shrink-0">
         <div className="flex items-center gap-4">
           <StatusChip name={question.statusId} />
@@ -103,7 +103,7 @@ function AnswererQuestionPreviewCard({ question }: AnswererQuestionPreviewCardPr
         </div>
       </div>
 
-      <div className='!select-text flex-1 min-h-0'>
+      <div className='!select-text flex-1 min-h-0 flex flex-col max-h-[64px]'>
         <ScrollBar className='h-full overflow-auto px-[var(--spacing-16)]'>
           <p className="!select-text text-[length:var(--font-size-medium)] leading-relaxed whitespace-pre-wrap break-all">
             {question.content}
@@ -319,8 +319,8 @@ type AnswerFormProps = {
 
 function AnswerForm({ title, preview, content, onChange, error, isSubmitting, onSubmit }: AnswerFormProps) {
   return (
-    <div style={{ width: '750px', maxWidth: '90vw' }} className="sm:px-0 flex flex-col max-h-[85vh] rounded-[var(--radius-big)] overflow-hidden">
-      <div className="pt-4 px-4 max-h-[220px] shrink-0">
+    <div style={{ width: '750px', maxWidth: '90vw' }} className="sm:px-0 flex flex-col max-h-[80vh] rounded-[var(--radius-big)] overflow-hidden">
+      <div className="pt-4 px-4 shrink-0">
         {preview}
       </div>
       <div className="flex flex-col gap-[var(--spacing-16)] px-4 pb-4 pt-2 items-center flex-1 overflow-y-auto">


### PR DESCRIPTION
# PR概要: 回答作成モーダルのレイアウト最適化（プレビューテキストの溢れ・閉じるボタンはみ出しの修正）

## 📝 概要
質問詳細画面（`frontend/app/routes/question.tsx`）から起動する回答作成モーダルにおいて、質問本文が長文の際にテキストがカードを突き破って溢れてしまう問題、および低解像度の画面でモーダル右上の「閉じる（×）ボタン」が画面上部にはみ出して操作できなくなるUI/UXの不具合を修正しました。

## 🔍 背景と課題
1. **プレビューのテキスト溢れ**: 
   親要素が `max-height` で制限されている場合、通常のブロック要素内では子要素（`ScrollBar`）の `h-full`（100%）の基準高がブラウザに正しく伝わらず無効化されていました。そのため、長文時に内部スクロールが発動せず、文字だけがカードを突き破って下の入力欄に被る現象が発生していました。
2. **閉じるボタンの画面外はみ出し**: 
   モーダル全体の最大高が `max-h-[85vh]` と大きく設定されていたため、上下中央配置（`items-center`）された際、縦幅の狭いディスプレイではモーダル枠が画面の天辺まで到達してしまい、外側に飛び出している「閉じるボタン」が画面外へ見えなくなっていました。

## 🛠️ 修正内容
`frontend/app/routes/question.tsx` の2つのコンポーネントに対し、CSSの高さ計算のバトンを正しく繋ぐためのレイアウト修正を行いました。

### 1. `AnswererQuestionPreviewCard`（プレビューカード側）
- カード自身（`<Card>`）に直接 **`max-h-[200px]`** と **`overflow-hidden`** を付与。中身が短い時は縮み、長い時はカチッと定位置で止まる安全網を敷きました。
- 本文を包む中間ラッパー要素（`div`）に **`flex flex-col max-h-[64px]`** を追加。親を Flexbox にすることで、直下にある `ScrollBar` の `h-full` をブラウザに強制的に認識させ、枠内での内部スクロールを100%駆動させました。

### 2. `AnswerForm`（モーダル・フォーム側）
- モーダル最外殻の最大高を **`max-h-[85vh]` から `max-h-[80vh]`** へと5%分引き下げました。
- プレビューを囲んでいた親側の余計な `max-h-[220px]` 制限を削除し、カード自身の自立した高さ制御に委ねる形にリファクタリングしました。
- 全体高を適度に絞ったことで、画面上端とモーダルの間に必ず安全なデッドスペース（隙間）が生まれるようになり、右上の閉じるボタンが絶対に画面内に収まるように位置を保護しました。

## 🧪