### PR TITLE
refactor: 質問作成モーダルを閉じた際の確認アラートの削除

### DIFF
--- a/frontend/app/components/common/Modal.tsx
+++ b/frontend/app/components/common/Modal.tsx
@@ -24,9 +24,7 @@ export default function Modal({ children, onClose }: ModalProps) {
     }, []); // 💡 初回表示時のみ実行
 
     const handleClose = () => {
-        if (confirm("本当に閉じますか？")) {
-            onClose();
-        }
+        onClose();
     }
 
     return (

--- a/frontend/app/components/common/Modal.tsx
+++ b/frontend/app/components/common/Modal.tsx
@@ -5,9 +5,11 @@ import { useEffect } from "react"; // 💡 修正1: useEffect をインポート
 type ModalProps = {
     children: React.ReactNode;
     onClose: () => void;
+    confirmOnClose?: boolean;
+    confirmCloseMessage?: string;
 }
 
-export default function Modal({ children, onClose }: ModalProps) {
+export default function Modal({ children, onClose, confirmOnClose = false, confirmCloseMessage }: ModalProps) {
     
     // 💡 修正2: 背景のスクロールを完全に止めるロジックを追加
     useEffect(() => {
@@ -24,6 +26,12 @@ export default function Modal({ children, onClose }: ModalProps) {
     }, []); // 💡 初回表示時のみ実行
 
     const handleClose = () => {
+        if (confirmOnClose) {
+            if (!confirm(confirmCloseMessage ?? "本当に閉じますか？")) {
+                return;
+            }
+        }
+
         onClose();
     }
 

--- a/frontend/app/routes/question.tsx
+++ b/frontend/app/routes/question.tsx
@@ -588,7 +588,7 @@ export default function QuestionPage() {
 
       {/* 回答投稿モーダル */}
       {isAnswerModalOpen && (
-        <Modal onClose={() => { setIsAnswerModalOpen(false); setAnswerContent(''); setAnswerError(''); }}>
+        <Modal confirmOnClose onClose={() => { setIsAnswerModalOpen(false); setAnswerContent(''); setAnswerError(''); }}>
           <AnswerForm
             title="回答を入力してください"
             preview={<AnswererQuestionPreviewCard question={question} />}
@@ -603,7 +603,7 @@ export default function QuestionPage() {
 
       {/* 回答への返信モーダル */}
       {replyTargetAnswerId !== null && replyTargetAnswer && (
-        <Modal onClose={() => { setReplyTargetAnswerId(null); setReplyContent(''); setReplyError(''); }}>
+        <Modal confirmOnClose onClose={() => { setReplyTargetAnswerId(null); setReplyContent(''); setReplyError(''); }}>
           <AnswerForm
             title="返信を入力してください"
             preview={<AnswerPreviewCard answer={replyTargetAnswer} />}
@@ -618,7 +618,7 @@ export default function QuestionPage() {
 
       {/* ThreadReply への返信モーダル */}
       {replyTargetReply !== null && (
-        <Modal onClose={() => { setReplyTargetReply(null); setReplyContent(''); setReplyError(''); }}>
+        <Modal confirmOnClose onClose={() => { setReplyTargetReply(null); setReplyContent(''); setReplyError(''); }}>
           <AnswerForm
             title="返信を入力してください"
             preview={<ReplyPreviewCard reply={replyTargetReply} />}


### PR DESCRIPTION
## 関連するイシュー
Closes #186 

## 変更内容
質問作成確認モーダルを閉じた際、余分に表示されていた確認アラート（アラーム）の処理を削除しました。

- モーダル閉じるボタン、および背景クリック時の挙動からアラートのトリガーを削除
- コードのクリーンアップ（不要になった関連関数や変数の削除）

## 影響範囲
質問作成画面の確認モーダル周辺のみ。既存の「作成処理」自体には影響ありません。

## 確認方法（レビューのポイント）
- [ ] 質問作成確認モーダルの「×ボタン」を押したとき、アラートを挟まずにモーダルが閉じること
- [ ] 背景のグレーアウト部分をクリックしたときも同様に、アラートなしで即座にモーダルが閉じること
- [ ] コンソールエラーなどが発生していないこと

## 変更前後の挙動（あれば）
- **変更前:** モーダルを閉じる ➔ 「本当に閉じますか？」等のアラートが出る ➔ 閉じる
- **変更後:** モーダルを閉じる ➔ 即座に閉じる