### PR TITLE
feat: ニックネーム未入力時のバリデーションエラーを追加

### DIFF
--- a/frontend/app/routes/profile.tsx
+++ b/frontend/app/routes/profile.tsx
@@ -116,6 +116,7 @@ export default function Profile() {
     // ─── 💡 ニックネーム更新処理 (Enterで発火) ───
     const handleNicknameChange = async () => {
         if (!nickname.trim()) {
+            setNicknameError("ニックネームを入力してください。");
             return;
         }
         if (nickname.length > 10) {


### PR DESCRIPTION
本文:
  ## Summary
  - ニックネームが未入力の場合、「ニックネームを入力してください。」とエラーを表示
  - ニックネームが11文字以上の場合、「文字数が制限を超えています。10文字以内で入力してください。」とエラーを表示
  - 画像アップロード時にファイル形式（jpg/png/gif以外）を検証し、不正な場合はエラーを表示
  - 画像アップロード時にファイルサイズ（5MB超過）を検証し、超過した場合はエラーを表示
  - バリデーションエラー時はすべてクライアント側で制御し、APIリクエストを送らない

  ## Test plan
  - [ ] ニックネームを空のままEnterを押すとエラーメッセージが表示されること
  - [ ] ニックネームを11文字以上入力してEnterを押すとエラーメッセージが表示されること
  - [ ] ニックネームを10文字以内で入力してEnterを押すと正常に更新されること
  - [ ] Escapeキーでキャンセルするとエラーがリセットされること
  - [ ] jpg/png/gif以外の画像を選択するとエラーメッセージが表示されること
  - [ ] 5MBを超える画像を選択するとエラーメッセージが表示されること
  - [ ] 正常な画像を選択するとアップロードが成功しトーストが表示されること