### PR TITLE
chore: 不要になったvite-tsconfig-pathsプラグインを削除し、Viteのネイティブ機能へ移行

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -44,8 +44,7 @@
         "tailwindcss": "^4.3.0",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.2",
-        "vite": "^8.0.9",
-        "vite-tsconfig-paths": "^6.1.1"
+        "vite": "^8.0.9"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4994,13 +4993,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -7320,42 +7312,6 @@
           "optional": true
         },
         "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite-tsconfig-paths": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
-      "integrity": "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "globrex": "^0.1.2",
-        "tsconfck": "^3.0.3"
-      },
-      "peerDependencies": {
-        "vite": "*"
-      }
-    },
-    "node_modules/vite-tsconfig-paths/node_modules/tsconfck": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,6 @@
     "tailwindcss": "^4.3.0",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.2",
-    "vite": "^8.0.9",
-    "vite-tsconfig-paths": "^6.1.1"
+    "vite": "^8.0.9"
   }
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,11 @@
 import { reactRouter } from "@react-router/dev/vite";
 import { defineConfig } from 'vite'
 import tailwindcss from '@tailwindcss/vite'
-import tsconfigPaths from "vite-tsconfig-paths"
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [reactRouter(), tailwindcss(), tsconfigPaths()],
+  plugins: [reactRouter(), tailwindcss()],
+  resolve: {
+    tsconfigPaths: true,
+  },
 })


### PR DESCRIPTION
### 概要
`npm run dev` 実行時に表示されていた `vite-tsconfig-paths` に関する警告（Viteが標準機能として tsconfig のパス解決をサポートした旨の通知）に対応するため、不要となった外部プラグインを削除し、Viteのネイティブ設定へ移行しました。

### 変更内容
* **パッケージ構成の修正 (`frontend/package.json`, `package-lock.json`)**
  * 不要になった `vite-tsconfig-paths` を依存関係から削除しました。
* **Vite設定ファイルの修正 (`frontend/vite.config.ts`)**
  * `vite-tsconfig-paths` のインポートおよび `plugins` 内でのプラグイン実行を削除しました。
  * `resolve: { tsconfigPaths: true }` を追加し、Vite標準の機能でパス解決（エイリアス等）を行うように設定を変更しました。

### 影響範囲
* 開発サーバーの起動（ローカル環境）およびビルド処理全般

### 動作確認・表示確認
- [ ] `npm run dev` 実行時に、`vite-tsconfig-paths` に関する警告メッセージが表示されなくなったこと
- [ ] プラグイン削除後も、相対パスやエイリアスを用いたコンポーネント等のインポートが壊れることなく、正常に開発サーバーが起動・画面表示できること