### PR TITLE
feature/最近解決した質問にmyActionsフィールドを追加

### DIFF
--- a/backend/src/routes/question.ts
+++ b/backend/src/routes/question.ts
@@ -247,7 +247,7 @@ router.get('/', requireAuth, async (req, res) => {
 
   if (q.user_id === userId) actions.push('my_questions');
   if (q.answers?.some((a: any) => a.user_id === userId && a.deleted_at === null)) actions.push('my_answers');
-  if (q.user_id === userId && q.answers?.some((a: any) => a.best_answer_at !== null)) actions.push('my_solved');
+  if (q.answers?.some((a: any) => a.user_id === userId && a.best_answer_at !== null)) actions.push('my_solved');
 
 
   return {

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -192,26 +192,25 @@ router.get('/me/recently-solved', requireAuth, async (req, res) => {
     return res.status(500).json({ error: answerError.message });
   }
 
-  const formatted = (bestAnswers ?? []).filter((a: any) => a.questions !== null).map((a: any) => {
-    const q = a.questions;
-    return {
-      id: q.id,
-      title: q.title,
-      statusId: q.statuses?.name,
-      myAction: 'my_answers',
-      userName: q.users?.nickname,
-      iconUrl: q.users?.profile_icon_url ?? null,
-      postingTime: q.created_at,
-      likeCount: q.question_likes?.length ?? 0,
-      bookmarkCount: q.bookmarks?.length ?? 0,
-      replyCount: q.answers?.filter((a: any) => a.parent_answer_id === null && a.deleted_at === null).length ?? 0,
-      tagNames: q.question_tags?.map((qt: any) => qt.tags?.name) ?? [],
-      isLiked: q.question_likes?.some((l: any) => l.user_id === userId) ?? false,
-      isBookmarked: q.bookmarks?.some((b: any) => b.user_id === userId) ?? false,
-    };
-  });
-
-  return res.json(formatted);
+ const formatted = (bestAnswers ?? []).filter((a: any) => a.questions !== null).map((a: any) => {
+  const q = a.questions;
+  return {
+    id: q.id,
+    title: q.title,
+    statusId: q.statuses?.name,
+    myActions: ['my_solved', 'my_answers'],
+    userName: q.users?.nickname,
+    iconUrl: q.users?.profile_icon_url ?? '',
+    postingTime: q.created_at,
+    likeCount: q.question_likes?.length ?? 0,
+    bookmarkCount: q.bookmarks?.length ?? 0,
+    replyCount: q.answers?.filter((a: any) => a.parent_answer_id === null && a.deleted_at === null).length ?? 0,
+    tagNames: q.question_tags?.map((qt: any) => qt.tags?.name) ?? [],
+    isLiked: q.question_likes?.some((l: any) => l.user_id === userId) ?? false,
+    isBookmarked: q.bookmarks?.some((b: any) => b.user_id === userId) ?? false,
+  };
+});
+return res.json(formatted);
 });
 
 // 1ヶ月ごとの回答件数取得


### PR DESCRIPTION
## 概要
最近解決した質問取得APIのレスポンスに`myActions`フィールドを追加する。

## 変更内容
- `myAction: 'my_answers'` を `myActions: ['my_solved', 'my_answers']` に変更

## 関連イシュー
closes #199 

## 確認事項
- [ ] レスポンスに `myActions` フィールドが含まれる
- [ ] `myActions` に `my_solved` が含まれる
- [ ] `myActions` に `my_answers` が含まれる