### PR TITLE
fix: プロフィールアイコンのサイズが画像によって変わる不具合を修正

### DIFF
--- a/frontend/app/routes/profile.tsx
+++ b/frontend/app/routes/profile.tsx
@@ -164,7 +164,7 @@ export default function Profile() {
 
 
                         <div className="flex-1 flex flex-col items-center justify-center gap-4 py-2 min-h-[120px]">
-                            <div className="flex flex-col items-center gap-2">
+                            <div className="flex flex-col items-center gap-2 w-full">
                                 <div className="relative w-full max-w-[140px] aspect-square text-[var(--main-color)] flex items-center justify-center rounded-full border">
                                     <Avatar src={profileData?.iconUrl || user?.iconUrl || "/images/default-avatar.png"} className="w-full h-full" />
                                     <label className=" transition-all hover:text-[var(--main-color)] hover:border-[var(--main-color)] hover:scale-110 absolute bottom-0 right-0 w-7 h-7 bg-white text-[var(--dark-gray)] border border-[var(--dark-gray)] rounded-full flex items-center justify-center cursor-pointer">


### PR DESCRIPTION
### 概要
プロフィール画面（`profile.tsx`）において、設定された画像のアスペクト比や元のサイズの違いによって、プロフィールアイコン（アバター）の表示サイズが意図せず変動してしまう不具合を修正しました。

### 原因と変更内容
* **原因**
  * アイコンの外枠を囲む親要素（`div`）に横幅の指定がなかったため、子要素であるアイコンコンテナ（`max-w-[140px]` や `aspect-square` を指定している部分）のサイズが、画像自体のサイズや要素全体の縮小ロジックに影響されて不安定になっていました。
* **変更内容 (`frontend/app/routes/profile.tsx`)**
  * ラッパーである `div` 要素のクラスに `w-full` を追加しました。これにより親要素の幅が担保され、子要素のアイコンサイズが常に意図した通り（最大幅 `140px` の正方形）で正しく維持・固定されるようになります。

### 影響範囲
* プロフィール詳細画面のユーザーアイコン表示部分

### 動作確認・表示確認
- [ ] 異なる縦横比（縦長・横長など）や異なる解像度の画像をプロフィールアイコンに設定しても、アイコンの表示サイズ（140x140pxの正方形）が崩れたり変わったりしないこと
- [ ] デフォルトのアイコン画像（`default-avatar.png`）が表示されている状態でも、表示サイズや位置に問題がないこと
- [ ] アイコン下部・周囲のレイアウト（カメラマークの配置など）が崩れていないこと