### PR TITLE
feat: ベストアンサーに選ぶ際に確認するように変更

### DIFF
--- a/frontend/app/routes/question.tsx
+++ b/frontend/app/routes/question.tsx
@@ -265,7 +265,11 @@ function AnswerCard({ answer, statusId, isOwner, currentUserId, onBestAnswer, on
         <div className="h-[40px] flex gap-8 items-center">
           {showBestAnswerButton && (
             <button
-              onClick={() => onBestAnswer(answer.id)}
+              onClick={() => {
+                const confirmed = window.confirm("この回答をベストアンサーに設定しますか？");
+                if (!confirmed) return;
+                onBestAnswer(answer.id)
+              }}
               className="transition-all hover:bg-[var(--main-color)] hover:text-white cursor-pointer flex items-center gap-1 text-[var(--main-color)] px-[var(--spacing-16)] py-[var(--spacing-8)] rounded-[4px] border border-[var(--main-color)]"
             >
               <EmojiEventsOutlinedIcon />


### PR DESCRIPTION
### 概要
質問詳細画面の回答カード（`AnswerCard`）において、誤操作によるベストアンサーの誤決定を防止するため、ベストアンサー選出ボタンをクリックした際にブラウザの確認ダイアログ（Confirm）を表示する機能を追加しました。

### 変更内容
* **回答カードコンポーネントの修正 (`frontend/app/routes/question.tsx`)**
  * ベストアンサー決定ボタンの `onClick` 処理を拡張しました。
  * `window.confirm("この回答をベストアンサーに設定しますか？")` を実装し、ユーザーが「キャンセル」を選択した場合は処理を中断（早期リターン）し、「OK」を選択した場合のみ確定処理（`onBestAnswer`）が実行されるようにロジックを変更しました。

### 影響範囲
* 質問詳細画面におけるベストアンサー選出操作

### 動作確認・表示確認
- [ ] ベストアンサー選出ボタンをクリックした際、ブラウザ標準の確認ダイアログ「この回答をベストアンサーに設定しますか？」が表示されること
- [ ] ダイアログで「キャンセル」をクリックした場合、確定処理が走らず状態が維持されること
- [ ] ダイアログで「OK」をクリックした場合、正しくベストアンサー確定処理（`onBestAnswer`）が実行されること