### PR TITLE
style: 質問カードのレスポンシブ対応（要素の折り返し）および質問作成モーダルの下部余白調整

### DIFF
--- a/frontend/app/components/top/QuestionCard.tsx
+++ b/frontend/app/components/top/QuestionCard.tsx
@@ -37,13 +37,13 @@ export default function QuestionCard({ question, isProfile }: QuestionCardProps)
             <Card className={`${isProfile ? "border border-[var(--light-gray)]" : ""}  transition-all hover:shadow-[var(--hover-box-shadow)] hover:bg-[var(--hover-color)] flex justify-between`}>
                 <div className='flex flex-col justify-space-around gap-[var(--spacing-16)]'>
                     {/* 一段目 */}
-                    <div className="flex items-center gap-[var(--spacing-16)]">
+                    <div className="flex items-center gap-[var(--spacing-16)] flex-wrap">
                         <StatusChip name={statusId} />
                         {
                             myActions.map((myAction) => {
                                 const targetAction = MY_ACTIONS.find((action) => action.id === myAction);
                                 return (
-                                    <div className={`bg-white border border-[var(--main-color)] rounded-[var(--radius-big)] inline-flex items-center justify-center text-[var(--main-color)] px-[var(--spacing-16)] py-[var(--spacing-12)]`}>
+                                    <div className={`bg-white border border-[var(--main-color)] rounded-[var(--radius-big)] inline-flex items-center justify-center text-[var(--main-color)] px-[var(--spacing-16)] py-[var(--spacing-12)]  shrink-0`}>
                                         <div className="flex items-center h-[12px]">{targetAction ? targetAction.name : ""}</div>
                                     </div>
                                 )

--- a/frontend/app/routes/createQuestion.tsx
+++ b/frontend/app/routes/createQuestion.tsx
@@ -296,7 +296,7 @@ export default function CreateQuestion() {
             {isModalOpen && (
                 <Modal onClose={() => setIsModalOpen(false)}>
                     <div style={{ width: '750px', maxWidth: '90vw' }} className="flex flex-col gap-[var(--spacing-8)] max-h-[80vh] overflow-hidden">
-                        <div className="px-4 flex-1 min-h-0 overflow-y-auto">
+                        <div className="px-4 flex-1 min-h-0 overflow-y-auto pb-2">
                             <Card>
                                 <div className="shrink-0 flex items-start justify-between py-[var(--spacing-16)]">
                                     <div className="flex items-start gap-4 min-w-0">


### PR DESCRIPTION
### 概要
画面幅が狭くなった際の表示崩れを防ぐためのレスポンシブ対応、およびモーダル内のスクロール領域における視認性向上のため、細かいスタイル（UI/UX）の調整を行いました。

### 変更内容
* **質問カードコンポーネント (`frontend/app/components/top/QuestionCard.tsx`)**
  * ステータスチップ（`StatusChip`）とアクションバッジ（`myActions`）を内包する親コンテナ（一段目）に `flex-wrap` を追加しました。これにより、画面幅が狭くなった際にバッジが自動で折り返されるようになります。
  * 各アクションバッジのコンテナに対して `shrink-0` を追加し、領域が狭まった際にもバッジ自体が潰れて（縮んで）文字が見えなくなるのを防いでいます。
* **質問作成画面 (`frontend/app/routes/createQuestion.tsx`)**
  * 質問作成モーダル内のスクロール可能なコンテンツ領域（`overflow-y-auto`）に、下部パディング `pb-2` を追加しました。これにより、最下部までスクロールした際にカードやコンテンツがモーダルの境界線にぴったり張り付くのを防ぎ、適度な余白（プロポーショナルな間隔）を確保しました。

### 影響範囲
* 質問カードが表示される画面全般（トップページなど）
* 質問作成モーダル

### 動作確認・表示確認
- [ ] **質問カード（レスポンシブ）**: 開発者ツールなどで画面幅を狭めた際、ステータス右側のアクションバッジが潰れることなく、綺麗に次の行へ折り返されること
- [ ] **質問作成モーダル**: モーダルを開いてコンテンツを最下部までスクロールした際、一番下の要素とモーダル枠の間に `pb-2` 分の適切な余白が確保されていること