### PR TITLE
fix: 他ユーザー回答の展開ボタンが表示されない不具合を修正

### DIFF
--- a/frontend/app/components/common/CardActionMenu.tsx
+++ b/frontend/app/components/common/CardActionMenu.tsx
@@ -7,7 +7,7 @@ import { FaTrashAlt } from "react-icons/fa";
 type CardActionMenuProps = {
     isContentOpen: boolean;
     setIsContentOpen: (isOpen: boolean) => void;
-    onRemove: () => void;
+    onRemove?: () => void;
     isOverflowing: boolean;
 };
 
@@ -29,25 +29,26 @@ export default function CardActionMenu({
     return (
         <div className="flex items-center text-[var(--dark-gray)] gap-4">
             {/* メニュー（3点リーダー） */}
-            <div className="relative">
-                <MoreVertOutlinedIcon
-                    className="cursor-pointer"
-                    onClick={() => setIsDropdownOpen(!isDropDownOpen)}
-                />
+            {onRemove && (
+                <div className="relative">
+                    <MoreVertOutlinedIcon
+                        className="cursor-pointer"
+                        onClick={() => setIsDropdownOpen(!isDropDownOpen)}
+                    />
 
-                {isDropDownOpen && (
-                    <div
-                        className="transition-all hover:bg-[var(--hover-color)] cursor-pointer flex items-center justify-center bg-white rounded-[var(--spacing-4)] absolute left-[100%] translate-x-[-100%] shadow-[var(--box-shadow)] border border-[var(--light-gray)] w-[128px] h-[40px] z-10"
-                        // onClick={handleRemove()} だとレンダリング時に即時実行されてしまうため、関数を渡す形に修正
-                        onClick={handleRemoveClick}
-                    >
-                        <button className="flex items-center justify-center gap-4 text-[var(--danger-color)] pointer-events-none">
-                            <FaTrashAlt />
-                            <p>削除</p>
-                        </button>
-                    </div>
-                )}
-            </div>
+                    {isDropDownOpen && (
+                        <div
+                            className="transition-all hover:bg-[var(--hover-color)] cursor-pointer flex items-center justify-center bg-white rounded-[var(--spacing-4)] absolute left-[100%] translate-x-[-100%] shadow-[var(--box-shadow)] border border-[var(--light-gray)] w-[128px] h-[40px] z-10"
+                            onClick={handleRemoveClick}
+                        >
+                            <button className="flex items-center justify-center gap-4 text-[var(--danger-color)] pointer-events-none">
+                                <FaTrashAlt />
+                                <p>削除</p>
+                            </button>
+                        </div>
+                    )}
+                </div>
+            )}
 
             {/* 開閉トグル（矢印アイコン） */}
             {isOverflowing && (

--- a/frontend/app/components/common/CardActionMenu.tsx
+++ b/frontend/app/components/common/CardActionMenu.tsx
@@ -20,10 +20,10 @@ export default function CardActionMenu({
     // ドロップダウンの開閉状態は、このコンポーネント内に閉じた状態(Local State)として管理します
     const [isDropDownOpen, setIsDropdownOpen] = useState(false);
 
-    // 削除処理のハンドラー
     const handleRemoveClick = () => {
-        onRemove(); // 親から渡された削除処理を実行
-        setIsDropdownOpen(false); // メニューを閉じる
+        if (!onRemove) return;
+        onRemove();
+        setIsDropdownOpen(false);
     };
 
     return (

--- a/frontend/app/components/questionDetail/ThreadReply.tsx
+++ b/frontend/app/components/questionDetail/ThreadReply.tsx
@@ -66,14 +66,12 @@ export default function ThreadReply({
                         <p>{userName}</p>
                         <Time postingTime={postingTime} />
                     </div>
-                    {userId === currentUserId && (
-                        <CardActionMenu
-                            isContentOpen={isContentOpen}
-                            setIsContentOpen={setIsContentOpen}
-                            onRemove={() => onDeleteReply?.(id)}
-                            isOverflowing={isOverflowing}
-                        />
-                    )}
+                    <CardActionMenu
+                        isContentOpen={isContentOpen}
+                        setIsContentOpen={setIsContentOpen}
+                        onRemove={userId === currentUserId ? () => onDeleteReply?.(id) : undefined}
+                        isOverflowing={isOverflowing}
+                    />
                 </div>
 
                 <CollapsibleContent

--- a/frontend/app/routes/question.tsx
+++ b/frontend/app/routes/question.tsx
@@ -219,19 +219,20 @@ function AnswerCard({ answer, statusId, isOwner, currentUserId, onBestAnswer, on
           <Time postingTime={answer.postingTime} />
         </div>
 
-        {answer.isBestAnswer ? (
-          <div className="flex items-center gap-2 text-[var(--main-color)]">
-            <EmojiEventsOutlinedIcon />
-            <p>ベストアンサー</p>
-          </div>
-        ) : (
+        <div className="flex items-center gap-2">
+          {answer.isBestAnswer && (
+            <div className="flex items-center gap-2 text-[var(--main-color)]">
+              <EmojiEventsOutlinedIcon />
+              <p>ベストアンサー</p>
+            </div>
+          )}
           <CardActionMenu
             isContentOpen={isContentOpen}
             setIsContentOpen={setIsContentOpen}
-            onRemove={answer.userId === currentUserId ? () => onDeleteAnswer(answer.id) : undefined}
+            onRemove={answer.userId === currentUserId && !answer.isBestAnswer ? () => onDeleteAnswer(answer.id) : undefined}
             isOverflowing={isOverflowing}
           />
-        )}
+        </div>
       </div>
 
       <CollapsibleContent

--- a/frontend/app/routes/question.tsx
+++ b/frontend/app/routes/question.tsx
@@ -224,14 +224,14 @@ function AnswerCard({ answer, statusId, isOwner, currentUserId, onBestAnswer, on
             <EmojiEventsOutlinedIcon />
             <p>ベストアンサー</p>
           </div>
-        ) : answer.userId === currentUserId ? (
+        ) : (
           <CardActionMenu
             isContentOpen={isContentOpen}
             setIsContentOpen={setIsContentOpen}
-            onRemove={() => onDeleteAnswer(answer.id)}
+            onRemove={answer.userId === currentUserId ? () => onDeleteAnswer(answer.id) : undefined}
             isOverflowing={isOverflowing}
           />
-        ) : null}
+        )}
       </div>
 
       <CollapsibleContent


### PR DESCRIPTION
## 原因
   `CardActionMenu` が三点リーダー（削除メニュー）と展開ボタンを1つのコンポーネントで管理しており、投稿者本人にしか表示されていなかったため、他ユーザーの投稿では展開ボタンも非表示になっていた。

   ## 修正内容

   - `CardActionMenu.tsx`: `onRemove` をオプショナルに変更し、渡された場合のみ三点リーダーを表示
   - `question.tsx`: 常に `CardActionMenu` をレンダリングし、自分の投稿のみ `onRemove` を渡すよう変更
   - `ThreadReply.tsx`: 同様に常に `CardActionMenu` をレンダリングし、自分の投稿のみ `onRemove` を渡すよう変更

   ## テスト観点

   - [ ] 自分の回答カード：三点リーダーと展開ボタンが両方表示される
   - [ ] 他ユーザーの回答カード：三点リーダーは非表示、4行以上の場合は展開ボタンが表示される
   - [ ] 返信（ThreadReply）でも同様に動作する