### PR TITLE
feat: バリデーションエラー時にエラー場所にスクロールする処理を追加

### DIFF
--- a/frontend/app/routes/createQuestion.tsx
+++ b/frontend/app/routes/createQuestion.tsx
@@ -43,6 +43,11 @@ export default function CreateQuestion() {
     const [isAiLoading, setIsAiLoading] = useState(false);
     const aiScrollRef = useRef<HTMLDivElement>(null);
 
+    //エラー時のスクロール用Ref
+    const titleRef = useRef<HTMLDivElement>(null);
+    const detailRef = useRef<HTMLDivElement>(null);
+    const tagsRef = useRef<HTMLDivElement>(null);
+
     const [errors, setErrors] = useState<{ title?: string; detail?: string; tags?: string }>({});
 
     // タグ一覧をバックエンドから取得
@@ -100,7 +105,19 @@ export default function CreateQuestion() {
         }
 
         setErrors(newErrors);
-        return Object.keys(newErrors).length === 0;
+        if (Object.keys(newErrors).length > 0) {
+            // 上にある要素から順番にチェックし、最初のエラー要素へスクロール
+            if (newErrors.title) {
+                titleRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            } else if (newErrors.detail) {
+                detailRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            } else if (newErrors.tags) {
+                tagsRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            }
+            return false; // エラーがある場合はfalse
+        }
+
+        return true; // エラーがない場合はtrue
     };
 
     const submitQuestion = async () => {
@@ -194,45 +211,48 @@ export default function CreateQuestion() {
 
     return (
         <div className="flex justify-center gap-4 overflow-x-hidden h-[calc(100vh-64px)]">
-            <ScrollBar className={`mr-1 flex-1 h-full overflow-y-auto flex flex-col gap-4 px-[var(--spacing-64)] py-[var(--spacing-32)] transition-all `}>
-                <div>
-                    <div className="py-[var(--spacing-16)]">
-                        <SectionTitle title="質問タイトル" isRequired>
-                            <button onClick={() => setIsAiOpen(!isAiOpen)} className="transition-all hover:shadow-[var(--hover-box-shadow)] shadow-[var(--box-shadow)] cursor-pointer rounded-[16px] text-white bg-[image:var(--ai-color)] px-[var(--spacing-32)] py-[var(--spacing-16)]">
-                                AIに相談する
-                            </button>
-                        </SectionTitle>
+            <div className="flex justify-center flex-1 overflow-x-hidden h-full py-4">
+                <ScrollBar className={`mr-1 flex-1 h-full overflow-y-auto flex flex-col gap-4 px-[var(--spacing-64)] py-[var(--spacing-16)] transition-all `}>
+                    <div>
+                        <div className="py-[var(--spacing-16)]" >
+                            <SectionTitle title="質問タイトル" isRequired>
+                                <button onClick={() => setIsAiOpen(!isAiOpen)} className="transition-all hover:shadow-[var(--hover-box-shadow)] shadow-[var(--box-shadow)] cursor-pointer rounded-[16px] text-white bg-[image:var(--ai-color)] px-[var(--spacing-32)] py-[var(--spacing-16)]">
+                                    AIに相談する
+                                </button>
+                            </SectionTitle>
+                        </div>
+                        <div className="flex flex-col gap-4 px-[var(--spacing-16)]" ref={titleRef}>
+                            <TextInput value={titleText} onChange={setTitleText} placeholder={titlePlaceholder} />
+                            {errors.title && <ErrorMessages message={errors.title} />}
+                        </div>
                     </div>
-                    <div className="flex flex-col gap-4 px-[var(--spacing-16)] ">
-                        <TextInput value={titleText} onChange={setTitleText} placeholder={titlePlaceholder} />
-                        {errors.title && <ErrorMessages message={errors.title} />}
+                    <div>
+                        <div className="py-[var(--spacing-16)]">
+                            <SectionTitle title="詳細" isRequired />
+                        </div>
+                        <div className="flex flex-col gap-4 px-[var(--spacing-16)]"  ref={detailRef}>
+                            <TextArea value={detailText} onChange={setDetailText} placeholder={detailPlaceholder} />
+                            {errors.detail && <ErrorMessages message={errors.detail} />}
+                        </div>
                     </div>
-                </div>
-                <div>
-                    <div className="py-[var(--spacing-16)]">
-                        <SectionTitle title="詳細" isRequired />
+                    <div className="relative">
+                        <div className="py-[var(--spacing-16)]" >
+                            <SectionTitle title="タグ付け" isRequired isTagSelect />
+                        </div>
+                        <div className="flex flex-col gap-4 px-[var(--spacing-16)]" ref={tagsRef}>
+                            {tagLoadError
+                                ? <ErrorMessages message={tagLoadError} />
+                                : <TagSelector selectedTagIds={selectedTagIds} setSelectedTagIds={setSelectedTagIds} allTagData={allTags} setErrors={setErrors} />
+                            }
+                            {errors.tags && <ErrorMessages message={errors.tags} />}
+                        </div>
                     </div>
-                    <div className="flex flex-col gap-4 px-[var(--spacing-16)]">
-                        <TextArea value={detailText} onChange={setDetailText} placeholder={detailPlaceholder} />
-                        {errors.detail && <ErrorMessages message={errors.detail} />}
+                    <div className="flex items-center justify-center">
+                        <Button text="内容確認" onClick={() => { if (validate()) setIsModalOpen(true); }} />
                     </div>
-                </div>
-                <div className="relative">
-                    <div className="py-[var(--spacing-16)]">
-                        <SectionTitle title="タグ付け" isRequired isTagSelect />
-                    </div>
-                    <div className="flex flex-col gap-4 px-[var(--spacing-16)]">
-                        {tagLoadError
-                            ? <ErrorMessages message={tagLoadError} />
-                            : <TagSelector selectedTagIds={selectedTagIds} setSelectedTagIds={setSelectedTagIds} allTagData={allTags} setErrors={setErrors}/>
-                        }
-                        {errors.tags && <ErrorMessages message={errors.tags} />}
-                    </div>
-                </div>
-                <div className="flex items-center justify-center">
-                    <Button text="内容確認" onClick={() => { if (validate()) setIsModalOpen(true); }} />
-                </div>
-            </ScrollBar>
+                </ScrollBar>
+            </div>
+
 
             {/* 右側：AIサポートアシスタント */}
             <div className={`${isAiOpen ? "flex-1" : "flex-0"} transition-all h-full flex flex-col rounded-l-[16px] shadow-[-4px_0px_4px_rgba(0,0,0,0.25)] overflow-hidden`}>


### PR DESCRIPTION
## 概要
質問作成画面（`CreateQuestion.tsx`）にて、フォーム送信時のバリデーションでエラーが発生した際、エラーに該当する入力エリアまで自動でスムーズにスクロールする機能を追加しました。

## 目的・背景
入力項目が多いフォームや画面が縦に長い場合、送信ボタンを押したあとに画面外（見えない位置）でエラーが発生していると、ユーザーがエラーに気づきにくいという課題がありました。
エラー箇所へ自動的に画面を移動させることで、ユーザーに修正が必要な箇所を直感的に伝え、ユーザー体験（UX）を向上させることを目的としています。

## 具体的な変更内容
- **Refの定義:** `useRef` を使用し、「タイトル」「詳細」「タグ」の各入力エリアの参照（`titleRef`, `detailRef`, `tagsRef`）を定義しました。
- **スクロール処理の追加:** バリデーション処理内でエラーが検出された場合、`scrollIntoView({ behavior: 'smooth', block: 'center' })` を実行する処理を追加しました。
  - 複数のエラーが同時に発生した場合は、画面上部にある要素（タイトル ＞ 詳細 ＞ タグ の優先順）へ優先してスクロールするように制御しています。
- **コンポーネント（JSX）への紐付け:** フォームの各該当ラッパー要素に `ref` を付与し、UIレイアウトに合わせた微調整を行いました。