### PR TITLE
refactor: question.tsxの切り分けられる部分コンポーネントに分離

### DIFF
--- a/frontend/app/components/questionDetail/AnswerCard.tsx
+++ b/frontend/app/components/questionDetail/AnswerCard.tsx
@@ -1,0 +1,136 @@
+import type { AnswerReplyType, AnswerType } from "@/types/answer";
+import { useState } from "react";
+import Card from "../common/Card";
+import Avatar from "../common/Avatar";
+import Time from "../common/Time";
+import CardActionMenu from '@/components/common/CardActionMenu';
+import CollapsibleContent from "../common/CollapsibleContent";
+import EmojiEventsOutlinedIcon from '@mui/icons-material/EmojiEventsOutlined';
+import KeyboardArrowDownOutlinedIcon from '@mui/icons-material/KeyboardArrowDownOutlined';
+import KeyboardArrowUpOutlinedIcon from '@mui/icons-material/KeyboardArrowUpOutlined';
+import Like from "../common/Like";
+import ThreadReply from "./ThreadReply";
+
+
+type AnswerCardProps = {
+    answer: AnswerType;
+    statusId: string;
+    isOwner: boolean;
+    currentUserId: string;
+    onBestAnswer: (answerId: string) => void;
+    onReply: (answerId: string) => void;
+    onThreadReply: (preview: { id: string; iconURL: string; userName: string; content: string; postingTime: string }) => void;
+    onDeleteAnswer: (answerId: string) => Promise<void>;
+    onDeleteReply: (replyId: string) => Promise<void>;
+};
+
+export default function AnswerCard({ answer, statusId, isOwner, currentUserId, onBestAnswer, onReply, onThreadReply, onDeleteAnswer, onDeleteReply }: AnswerCardProps) {
+    const [isReplyOpen, setIsReplyOpen] = useState(false);
+    const [isContentOpen, setIsContentOpen] = useState(false);
+    const [isOverflowing, setIsOverflowing] = useState(false);
+
+    const isResolved = statusId === '解決済み';
+    const showBestAnswerButton = isOwner && !isResolved && !answer.isBestAnswer;
+
+    return (
+        <Card
+            className={[
+                'flex flex-col gap-2',
+                answer.isBestAnswer ? 'border-r-4 border-r-[var(--main-color)]' : '',
+            ].join(' ')}
+        >
+            <div className="flex justify-between items-center">
+                <div className="flex gap-2 py-[4px]">
+                    <Avatar src={answer.iconURL} className="w-[32px] h-[32px]" />
+                    <p>{answer.userName}</p>
+                    <Time postingTime={answer.postingTime} />
+                </div>
+
+                <div className="flex items-center gap-2">
+                    {answer.isBestAnswer && (
+                        <div className="flex items-center gap-2 text-[var(--main-color)]">
+                            <EmojiEventsOutlinedIcon />
+                            <p>ベストアンサー</p>
+                        </div>
+                    )}
+                    <CardActionMenu
+                        isContentOpen={isContentOpen}
+                        setIsContentOpen={setIsContentOpen}
+                        onRemove={answer.userId === currentUserId && !answer.isBestAnswer ? () => onDeleteAnswer(answer.id) : undefined}
+                        isOverflowing={isOverflowing}
+                    />
+                </div>
+            </div>
+
+            <CollapsibleContent
+                content={answer.content}
+                isContentOpen={isContentOpen}
+                setIsContentOpen={setIsContentOpen}
+                setIsOverflowing={setIsOverflowing}
+            />
+
+            <div className="flex justify-between items-center">
+                <div className="flex items-center gap-4">
+                    <button
+                        className="cursor-pointer rounded-[4px] w-[88px] h-[32px] flex items-center justify-center border border-[var(--accent-color)] text-[var(--accent-color)] hover:bg-[var(--accent-color)] hover:text-white transition-all"
+                        onClick={() => onReply(answer.id)}
+                    >
+                        返信
+                    </button>
+
+                    {answer.replies.length > 0 && (
+                        <button
+                            className="flex items-center text-[var(--dark-gray)] cursor-pointer"
+                            onClick={() => setIsReplyOpen((prev) => !prev)}
+                        >
+                            {isReplyOpen ? '返信を非表示' : '返信を表示'}
+                            ({answer.replies.length})
+                            {isReplyOpen ? <KeyboardArrowUpOutlinedIcon /> : <KeyboardArrowDownOutlinedIcon />}
+                        </button>
+                    )}
+                </div>
+
+                <div className="h-[40px] flex gap-8 items-center">
+                    {showBestAnswerButton && (
+                        <button
+                            onClick={() => {
+                                const confirmed = window.confirm("この回答をベストアンサーに設定しますか？");
+                                if (!confirmed) return;
+                                onBestAnswer(answer.id)
+                            }}
+                            className="transition-all hover:bg-[var(--main-color)] hover:text-white cursor-pointer flex items-center gap-1 text-[var(--main-color)] px-[var(--spacing-16)] py-[var(--spacing-8)] rounded-[4px] border border-[var(--main-color)]"
+                        >
+                            <EmojiEventsOutlinedIcon />
+                            <p>ベストアンサーに選ぶ</p>
+                        </button>
+                    )}
+                    <Like id={answer.id} type="answer" count={answer.likeCount} isLiked={answer.isLiked} />
+                </div>
+            </div>
+
+            {isReplyOpen && answer.replies.length > 0 && (
+                <div className="flex flex-col gap-4">
+                    <div className="bg-[var(--light-gray)] h-[1px] w-full" />
+                    {answer.replies.map((reply: AnswerReplyType) => (
+                        <ThreadReply
+                            key={reply.id}
+                            id={reply.id}
+                            userId={reply.userId}
+                            iconURL={reply.iconURL}
+                            userName={reply.userName}
+                            content={reply.content}
+                            postingTime={reply.postingTime}
+                            likeCount={reply.likeCount}
+                            isLiked={reply.isLiked}
+                            replies={reply.replies}
+                            depth={1}
+                            currentUserId={currentUserId}
+                            onReply={(preview) => onThreadReply(preview)}
+                            onDeleteReply={onDeleteReply}
+                        />
+                    ))}
+                </div>
+            )}
+        </Card>
+    );
+}

--- a/frontend/app/components/questionDetail/AnswerFormModal.tsx
+++ b/frontend/app/components/questionDetail/AnswerFormModal.tsx
@@ -1,0 +1,75 @@
+// src/components/questionDetail/AnswerFormModal.tsx
+
+import { useState } from 'react';
+import Modal from '@/components/common/Modal';
+import TextArea from '@/components/common/Textarea';
+import ErrorMessages from '@/components/common/ErrorMessages';
+import Button from '@/components/common/Button';
+
+type AnswerFormModalProps = {
+    title: string;
+    preview: React.ReactNode;
+    submitText: string;
+    onClose: () => void;
+    onSubmit: (content: string) => Promise<void>;
+};
+
+export default function AnswerFormModal({ title, preview, submitText, onClose, onSubmit }: AnswerFormModalProps) {
+    const [content, setContent] = useState('');
+    const [error, setError] = useState('');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const handleSubmit = async () => {
+        if (!content.trim()) {
+            setError('内容を入力してください');
+            return;
+        }
+        if (content.length > 5000) {
+            setError('文字数制限を超えています。5000文字以内で入力してください。');
+            return;
+        }
+
+        setIsSubmitting(true);
+        setError('');
+        try {
+            await onSubmit(content);
+        } catch {
+            setError('投稿に失敗しました。時間をおいて再度お試しください。');
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <Modal confirmOnClose onClose={onClose}>
+            <div style={{ width: '750px', maxWidth: '90vw' }} className="flex flex-col max-h-[80vh] rounded-[var(--radius-big)] overflow-hidden">
+                <div className="pt-4 px-4 shrink-0">
+                    {preview}
+                </div>
+                <div className="flex flex-col gap-[var(--spacing-16)] px-4 pb-4 pt-2 items-center flex-1 overflow-y-auto">
+                    <label className="w-full flex py-[var(--spacing-8)] justify-between items-center border-b border-[var(--main-color)] shrink-0">
+                        <p className="text-[length:var(--font-size-big)]">
+                            {title} <span className="text-[var(--danger-color)]">*</span>
+                        </p>
+                    </label>
+
+                    <TextArea
+                        placeholder="例：setStateによる更新は非同期で行われるため、同じレンダーサイクル内では古い値を参照してしまうからです。"
+                        value={content}
+                        onChange={setContent}
+                        rows={5}
+                    />
+
+                    {error && <ErrorMessages message={error} />}
+
+                    <Button
+                        className='w-[344px] shrink-0'
+                        onClick={handleSubmit}
+                        text={isSubmitting ? '送信中...' : submitText}
+                        disabled={isSubmitting}
+                    />
+                </div>
+            </div>
+        </Modal>
+    );
+}

--- a/frontend/app/components/questionDetail/QuestionDetailCard.tsx
+++ b/frontend/app/components/questionDetail/QuestionDetailCard.tsx
@@ -14,9 +14,10 @@ import { type QuestionType } from "@/types/question.ts";
 type QuestionDetailCardProps = {
     question: QuestionType & { content?: string };
     onDelete?: () => void;
+    isOwner?: boolean
 }
 
-export default function QuestionDetailCard({ question, onDelete }: QuestionDetailCardProps) {
+export default function QuestionDetailCard({ question, onDelete, isOwner }: QuestionDetailCardProps) {
     const {
         id,
         title,
@@ -52,7 +53,7 @@ export default function QuestionDetailCard({ question, onDelete }: QuestionDetai
                 <CardActionMenu
                     isContentOpen={isContentOpen}
                     setIsContentOpen={setIsContentOpen}
-                    onRemove={handleRemove}
+                    onRemove={isOwner ? handleRemove : undefined}
                     isOverflowing={isOverflowing}
                 />
             </div>

--- a/frontend/app/components/questionDetail/QuestionPreviewCards.tsx
+++ b/frontend/app/components/questionDetail/QuestionPreviewCards.tsx
@@ -1,0 +1,82 @@
+// src/components/questionDetail/QuestionPreviewCards.tsx
+
+import Card from '@/components/common/Card';
+import Avatar from '@/components/common/Avatar';
+import Time from '@/components/common/Time';
+import Like from '@/components/common/Like';
+import Bookmark from '@/components/common/Bookmark';
+import Comment from '@/components/common/Comment';
+import StatusChip from '@/components/common/StatusChip';
+import TagChip from '@/components/common/TagChip';
+import ScrollBar from '@/components/common/ScrollBar';
+
+import type { QuestionDetail } from '@/types/question';
+import type { AnswerType, AnswerReplyType } from '@/types/answer';
+
+// 回答作成時の質問プレビュー専用
+export function AnswererQuestionPreviewCard({ question }: { question: QuestionDetail }) {
+    return (
+        <Card className="w-full px-4 py-2 flex flex-col h-full max-h-[200px] overflow-hidden">
+            <div className="flex items-center justify-between pb-[var(--spacing-16)] shrink-0">
+                <div className="flex items-center gap-4">
+                    <StatusChip name={question.statusId} />
+                    <h2 className="text-[length:var(--font-size-big)]">{question.title}</h2>
+                </div>
+            </div>
+            <div className='!select-text flex-1 min-h-0 flex flex-col max-h-[64px]'>
+                <ScrollBar className='h-full overflow-auto px-[var(--spacing-16)]'>
+                    <p className="!select-text text-[length:var(--font-size-medium)] leading-relaxed whitespace-pre-wrap break-all">
+                        {question.content}
+                    </p>
+                </ScrollBar>
+            </div>
+            <div className="px-[var(--spacing-16)] py-[var(--spacing-8)] flex items-center justify-between shrink-0">
+                <div className="flex flex-wrap gap-2">
+                    {question.tagNames?.map((tag, idx) => <TagChip key={idx} text={tag} />)}
+                </div>
+                <div className="flex items-center gap-2">
+                    <Bookmark id={question.id} isBookmarked={question.isBookmarked ?? false} count={question.bookmarkCount} />
+                    <Like id={question.id} type='question' isLiked={question.isLiked ?? false} count={question.likeCount} />
+                    <Comment count={question.replyCount} />
+                </div>
+            </div>
+        </Card>
+    );
+}
+
+// 回答返信モーダル内のプレビューカード
+export function AnswerPreviewCard({ answer }: { answer: AnswerType }) {
+    return (
+        <Card className="w-full">
+            <div className="flex gap-2 py-[4px] mb-2">
+                <Avatar src={answer.iconURL} className="w-[32px] h-[32px]" />
+                <p>{answer.userName}</p>
+                <Time postingTime={answer.postingTime} />
+            </div>
+            <ScrollBar className='max-h-[64px] overflow-auto px-[var(--spacing-16)]'>
+                <p className="!select-text text-[length:var(--font-size-medium)] leading-relaxed">
+                    {answer.content}
+                </p>
+            </ScrollBar>
+            <div className="flex justify-end mt-2">
+                <Like id={answer.id} type='answer' count={answer.likeCount} isLiked={answer.isLiked} />
+            </div>
+        </Card>
+    );
+}
+
+// ThreadReply返信モーダル内のプレビューカード
+export function ReplyPreviewCard({ reply }: { reply: Pick<AnswerReplyType, 'iconURL' | 'userName' | 'content' | 'postingTime'> }) {
+    return (
+        <Card className="w-full">
+            <div className="flex gap-2 py-[4px] mb-2">
+                <Avatar src={reply.iconURL} className="w-[32px] h-[32px]" />
+                <p>{reply.userName}</p>
+                <Time postingTime={reply.postingTime} />
+            </div>
+            <p className="!select-text px-[var(--spacing-16)] text-[length:var(--font-size-medium)] leading-relaxed max-h-[120px] overflow-auto">
+                {reply.content}
+            </p>
+        </Card>
+    );
+}

--- a/frontend/app/routes/question.tsx
+++ b/frontend/app/routes/question.tsx
@@ -1,359 +1,28 @@
 // routes/question.tsx — 質問詳細ページ
 
-import { useState, useEffect } from 'react';
-import { useParams } from 'react-router';
+import { useState, useEffect, useCallback } from 'react';
+import { useParams, useNavigate } from 'react-router';
 
-import Card from '@/components/common/Card';
-import Avatar from '@/components/common/Avatar';
-import Time from '@/components/common/Time';
-import Like from '@/components/common/Like';
-import Bookmark from '@/components/common/Bookmark';
-import Comment from '@/components/common/Comment';
-import StatusChip from '@/components/common/StatusChip';
-import TagChip from '@/components/common/TagChip';
-import CardActionMenu from '@/components/common/CardActionMenu';
-import CollapsibleContent from '@/components/common/CollapsibleContent';
 import ScrollBar from '@/components/common/ScrollBar';
-import Modal from '@/components/common/Modal';
-import TextArea from '@/components/common/Textarea';
-import ErrorMessages from '@/components/common/ErrorMessages';
-import Header from '@/components/common/Header';
 import Loading from '@/components/common/Loading';
-
+import Button from '@/components/common/Button';
 import QuestionDetailCard from '@/components/questionDetail/QuestionDetailCard';
-import ThreadReply from '@/components/questionDetail/ThreadReply';
+import AnswerCard from '@/components/questionDetail/AnswerCard';
+
+import AnswerFormModal from '@/components/questionDetail/AnswerFormModal';
+import {
+  AnswererQuestionPreviewCard,
+  AnswerPreviewCard,
+  ReplyPreviewCard
+} from '@/components/questionDetail/QuestionPreviewCards';
 
 import type { QuestionDetail } from '@/types/question';
-import type { AnswerType, AnswerReplyType } from '@/types/answer';
+import type { AnswerType } from '@/types/answer';
 
 import { getQuestionById, getQuestionAnswers, postAnswer, deleteQuestion } from '@/api/questionService';
 import { acceptAnswer, deleteAnswer } from '@/api/answerService';
 import { useUser } from '@/contexts/UserContext';
-import { useNavigate } from 'react-router';
 import { toast } from '@/utils/toast';
-
-import EmojiEventsOutlinedIcon from '@mui/icons-material/EmojiEventsOutlined';
-import KeyboardArrowDownOutlinedIcon from '@mui/icons-material/KeyboardArrowDownOutlined';
-import KeyboardArrowUpOutlinedIcon from '@mui/icons-material/KeyboardArrowUpOutlined';
-import Button from '@/components/common/Button';
-
-
-// ═════════════════════════════════════════
-// AnswererQuestionCard（回答者向け質問カード）
-// ─────────────────────────────────────────
-
-type AnswererQuestionCardProps = {
-  question: QuestionDetail;
-};
-
-function AnswererQuestionCard({ question }: AnswererQuestionCardProps) {
-  const [isContentOpen, setIsContentOpen] = useState(false);
-  const [isOverflowing, setIsOverflowing] = useState(false);
-
-  return (
-    <Card className="w-full">
-      <div className="flex items-center justify-between py-[var(--spacing-16)]">
-        <div className="flex items-center gap-4">
-          <StatusChip name={question.statusId} />
-          <h2 className="text-[length:var(--font-size-big)]">{question.title}</h2>
-        </div>
-        {isOverflowing && (
-          isContentOpen
-            ? <KeyboardArrowUpOutlinedIcon className="cursor-pointer text-[var(--dark-gray)]" onClick={() => setIsContentOpen(false)} />
-            : <KeyboardArrowDownOutlinedIcon className="cursor-pointer text-[var(--dark-gray)]" onClick={() => setIsContentOpen(true)} />
-        )}
-      </div>
-      <div className='!select-text'>
-        <CollapsibleContent
-          content={question.content}
-          isContentOpen={isContentOpen}
-          setIsContentOpen={setIsContentOpen}
-          setIsOverflowing={setIsOverflowing}
-        />
-      </div>
-
-      <div className="px-[var(--spacing-16)] py-[var(--spacing-8)] flex items-center justify-between">
-        <div className="flex flex-wrap gap-2">
-          {question.tagNames?.map((tag, index) => (
-            <TagChip key={index} text={tag} />
-          ))}
-        </div>
-        <div className="flex items-center gap-2">
-          <Bookmark id={question.id} isBookmarked={question.isBookmarked ?? false} count={question.bookmarkCount} />
-          <Like id={question.id} type='question' isLiked={question.isLiked ?? false} count={question.likeCount} />
-          <Comment count={question.replyCount} />
-        </div>
-      </div>
-    </Card>
-  );
-}
-
-type AnswererQuestionPreviewCardProps = {
-  question: QuestionDetail;
-};
-
-//回答作成時の質問プレビュー専用
-function AnswererQuestionPreviewCard({ question }: AnswererQuestionPreviewCardProps) {
-  return (
-    <Card className="w-full px-4 py-2 flex flex-col h-full max-h-[200px] overflow-hidden">
-      <div className="flex items-center justify-between pb-[var(--spacing-16)] shrink-0">
-        <div className="flex items-center gap-4">
-          <StatusChip name={question.statusId} />
-          <h2 className="text-[length:var(--font-size-big)]">{question.title}</h2>
-        </div>
-      </div>
-
-      <div className='!select-text flex-1 min-h-0 flex flex-col max-h-[64px]'>
-        <ScrollBar className='h-full overflow-auto px-[var(--spacing-16)]'>
-          <p className="!select-text text-[length:var(--font-size-medium)] leading-relaxed whitespace-pre-wrap break-all">
-            {question.content}
-          </p>
-        </ScrollBar>
-      </div>
-
-      <div className="px-[var(--spacing-16)] py-[var(--spacing-8)] flex items-center justify-between shrink-0">
-        <div className="flex flex-wrap gap-2">
-          {question.tagNames?.map((tag, index) => (
-            <TagChip key={index} text={tag} />
-          ))}
-        </div>
-        <div className="flex items-center gap-2">
-          <Bookmark id={question.id} isBookmarked={question.isBookmarked ?? false} count={question.bookmarkCount} />
-          <Like id={question.id} type='question' isLiked={question.isLiked ?? false} count={question.likeCount} />
-          <Comment count={question.replyCount} />
-        </div>
-      </div>
-    </Card>
-  );
-}
-
-// ═════════════════════════════════════════
-// AnswerPreviewCard（回答返信モーダル内のプレビューカード）
-
-type AnswerPreviewCardProps = {
-  answer: AnswerType;
-};
-
-function AnswerPreviewCard({ answer }: AnswerPreviewCardProps) {
-  return (
-    <Card className="w-full">
-      <div className="flex gap-2 py-[4px] mb-2">
-        <Avatar src={answer.iconURL} className="w-[32px] h-[32px]" />
-        <p>{answer.userName}</p>
-        <Time postingTime={answer.postingTime} />
-      </div>
-      <ScrollBar className='max-h-[64px] overflow-auto px-[var(--spacing-16)]'>
-        <p className="!select-text text-[length:var(--font-size-medium)] leading-relaxed ">
-          {answer.content}
-        </p>
-      </ScrollBar>
-      <div className="flex justify-end mt-2">
-        <Like id={answer.id} type='answer' count={answer.likeCount} isLiked={answer.isLiked} />
-      </div>
-    </Card>
-  );
-}
-
-
-// ReplyPreviewCard（ThreadReply返信モーダル内のプレビューカード）
-
-type ReplyPreviewCardProps = {
-  reply: {
-    iconURL: string;
-    userName: string;
-    content: string;
-    postingTime: string;
-  };
-};
-
-function ReplyPreviewCard({ reply }: ReplyPreviewCardProps) {
-  return (
-    <Card className="w-full">
-      <div className="flex gap-2 py-[4px] mb-2">
-        <Avatar src={reply.iconURL} className="w-[32px] h-[32px]" />
-        <p>{reply.userName}</p>
-        <Time postingTime={reply.postingTime} />
-      </div>
-      <p className="!select-text px-[var(--spacing-16)] text-[length:var(--font-size-medium)] leading-relaxed max-h-[120px] overflow-auto">
-        {reply.content}
-      </p>
-    </Card>
-  );
-}
-
-
-// ═════════════════════════════════════════
-// AnswerCard（回答カード）
-
-type AnswerCardProps = {
-  answer: AnswerType;
-  statusId: string;
-  isOwner: boolean;
-  currentUserId: string;
-  onBestAnswer: (answerId: string) => void;
-  onReply: (answerId: string) => void;
-  onThreadReply: (preview: { id: string; iconURL: string; userName: string; content: string; postingTime: string }) => void;
-  onDeleteAnswer: (answerId: string) => Promise<void>;
-  onDeleteReply: (replyId: string) => Promise<void>;
-};
-
-function AnswerCard({ answer, statusId, isOwner, currentUserId, onBestAnswer, onReply, onThreadReply, onDeleteAnswer, onDeleteReply }: AnswerCardProps) {
-  const [isReplyOpen, setIsReplyOpen] = useState(false);
-  const [isContentOpen, setIsContentOpen] = useState(false);
-  const [isOverflowing, setIsOverflowing] = useState(false);
-
-  const isResolved = statusId === '解決済み';
-  const showBestAnswerButton = isOwner && !isResolved && !answer.isBestAnswer;
-
-  return (
-    <Card
-      className={[
-        'flex flex-col gap-2',
-        answer.isBestAnswer ? 'border-r-4 border-r-[var(--main-color)]' : '',
-      ].join(' ')}
-    >
-      <div className="flex justify-between items-center">
-        <div className="flex gap-2 py-[4px]">
-          <Avatar src={answer.iconURL} className="w-[32px] h-[32px]" />
-          <p>{answer.userName}</p>
-          <Time postingTime={answer.postingTime} />
-        </div>
-
-        <div className="flex items-center gap-2">
-          {answer.isBestAnswer && (
-            <div className="flex items-center gap-2 text-[var(--main-color)]">
-              <EmojiEventsOutlinedIcon />
-              <p>ベストアンサー</p>
-            </div>
-          )}
-          <CardActionMenu
-            isContentOpen={isContentOpen}
-            setIsContentOpen={setIsContentOpen}
-            onRemove={answer.userId === currentUserId && !answer.isBestAnswer ? () => onDeleteAnswer(answer.id) : undefined}
-            isOverflowing={isOverflowing}
-          />
-        </div>
-      </div>
-
-      <CollapsibleContent
-        content={answer.content}
-        isContentOpen={isContentOpen}
-        setIsContentOpen={setIsContentOpen}
-        setIsOverflowing={setIsOverflowing}
-      />
-
-      <div className="flex justify-between items-center">
-        <div className="flex items-center gap-4">
-          <button
-            className="cursor-pointer rounded-[4px] w-[88px] h-[32px] flex items-center justify-center border border-[var(--accent-color)] text-[var(--accent-color)] hover:bg-[var(--accent-color)] hover:text-white transition-all"
-            onClick={() => onReply(answer.id)}
-          >
-            返信
-          </button>
-
-          {answer.replies.length > 0 && (
-            <button
-              className="flex items-center text-[var(--dark-gray)] cursor-pointer"
-              onClick={() => setIsReplyOpen((prev) => !prev)}
-            >
-              {isReplyOpen ? '返信を非表示' : '返信を表示'}
-              ({answer.replies.length})
-              {isReplyOpen ? <KeyboardArrowUpOutlinedIcon /> : <KeyboardArrowDownOutlinedIcon />}
-            </button>
-          )}
-        </div>
-
-        <div className="h-[40px] flex gap-8 items-center">
-          {showBestAnswerButton && (
-            <button
-              onClick={() => {
-                const confirmed = window.confirm("この回答をベストアンサーに設定しますか？");
-                if (!confirmed) return;
-                onBestAnswer(answer.id)
-              }}
-              className="transition-all hover:bg-[var(--main-color)] hover:text-white cursor-pointer flex items-center gap-1 text-[var(--main-color)] px-[var(--spacing-16)] py-[var(--spacing-8)] rounded-[4px] border border-[var(--main-color)]"
-            >
-              <EmojiEventsOutlinedIcon />
-              <p>ベストアンサーに選ぶ</p>
-            </button>
-          )}
-          <Like id={answer.id} type="answer" count={answer.likeCount} isLiked={answer.isLiked} />
-        </div>
-      </div>
-
-      {isReplyOpen && answer.replies.length > 0 && (
-        <div className="flex flex-col gap-4">
-          <div className="bg-[var(--light-gray)] h-[1px] w-full" />
-          {answer.replies.map((reply: AnswerReplyType) => (
-            <ThreadReply
-              key={reply.id}
-              id={reply.id}
-              userId={reply.userId}
-              iconURL={reply.iconURL}
-              userName={reply.userName}
-              content={reply.content}
-              postingTime={reply.postingTime}
-              likeCount={reply.likeCount}
-              isLiked={reply.isLiked}
-              replies={reply.replies}
-              depth={1}
-              currentUserId={currentUserId}
-              onReply={(preview) => onThreadReply(preview)}
-              onDeleteReply={onDeleteReply}
-            />
-          ))}
-        </div>
-      )}
-    </Card>
-  );
-}
-
-
-// ═════════════════════════════════════════
-// AnswerForm（回答・返信フォーム）
-
-type AnswerFormProps = {
-  title: string;
-  preview: React.ReactNode;
-  content: string;
-  onChange: (v: string) => void;
-  error: string;
-  isSubmitting: boolean;
-  onSubmit: () => void;
-};
-
-function AnswerForm({ title, preview, content, onChange, error, isSubmitting, onSubmit }: AnswerFormProps) {
-  return (
-    <div style={{ width: '750px', maxWidth: '90vw' }} className="sm:px-0 flex flex-col max-h-[80vh] rounded-[var(--radius-big)] overflow-hidden">
-      <div className="pt-4 px-4 shrink-0">
-        {preview}
-      </div>
-      <div className="flex flex-col gap-[var(--spacing-16)] px-4 pb-4 pt-2 items-center flex-1 overflow-y-auto">
-        <label className="w-full flex py-[var(--spacing-8)] justify-between items-center border-b border-[var(--main-color)] shrink-0">
-          <p className="text-[length:var(--font-size-big)]">
-            {title}
-            <span className="text-[var(--danger-color)]">*</span>
-          </p>
-        </label>
-
-        <TextArea
-          placeholder="例：setStateによる更新は非同期で行われるため、同じレンダーサイクル内では古い値を参照してしまうからです。"
-          value={content}
-          onChange={onChange}
-          rows={5}
-        />
-
-        {error && <ErrorMessages message={error} />}
-
-        <Button className='w-[344px] shrink-0' onClick={onSubmit} text={isSubmitting ? '送信中...' : '回答送信'} disabled={isSubmitting} />
-      </div>
-    </div>
-  );
-}
-
-
-// ═════════════════════════════════════════
-// QuestionPage（メインページ）
 
 export default function QuestionPage() {
   const { id } = useParams<{ id: string }>();
@@ -364,139 +33,62 @@ export default function QuestionPage() {
   const [answers, setAnswers] = useState<AnswerType[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
-  const isOwner = user?.id === question?.userId;
-
   const [isAnswerModalOpen, setIsAnswerModalOpen] = useState(false);
-  const [answerContent, setAnswerContent] = useState('');
-  const [answerError, setAnswerError] = useState('');
-  const [isAnswerSubmitting, setIsAnswerSubmitting] = useState(false);
 
-  const [replyTargetAnswerId, setReplyTargetAnswerId] = useState<string | null>(null);
-  const [replyContent, setReplyContent] = useState('');
-  const [replyError, setReplyError] = useState('');
-  const [isReplySubmitting, setIsReplySubmitting] = useState(false);
-
-  const [replyTargetReply, setReplyTargetReply] = useState<{
-    id: string;
-    iconURL: string;
-    userName: string;
-    content: string;
-    postingTime: string;
+  // 返信対象（「回答」か「スレッド内のリプライ」か）を一元管理するState
+  const [replyTarget, setReplyTarget] = useState<{
+    parentId: string;
+    type: 'answer' | 'thread';
+    previewData: any;
   } | null>(null);
 
+  const isOwner = user?.id === question?.userId;
 
-  // 質問と回答を取得
-  useEffect(() => {
+  // データ同期用共通関数
+  const refreshAnswers = useCallback(async () => {
     if (!id) return;
-
-    const fetchData = async () => {
-      setIsLoading(true);
-      try {
-        const [q, a] = await Promise.all([
-          getQuestionById(id),
-          getQuestionAnswers(id),
-        ]);
-        setQuestion(q);
-        setAnswers(a);
-      } catch (err) {
-        console.error('データ取得エラー:', err);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchData();
+    try {
+      const [updatedAnswers, updatedQuestion] = await Promise.all([
+        getQuestionAnswers(id),
+        getQuestionById(id),
+      ]);
+      setAnswers(updatedAnswers);
+      setQuestion(updatedQuestion);
+    } catch (err) {
+      console.error('データ更新エラー:', err);
+    }
   }, [id]);
 
-
-  const validate = (text: string, setError: (msg: string) => void): boolean => {
-    if (!text.trim()) {
-      setError('内容を入力してください');
-      return true;
-    }
-    if (text.length > 5000) {
-      setError('文字数制限を超えています。5000文字以内で入力してください。');
-      return true;
-    }
-    return false;
-  };
-
-  const refreshAnswers = async () => {
+  useEffect(() => {
     if (!id) return;
-    const [updated, updatedQuestion] = await Promise.all([
-      getQuestionAnswers(id),
-      getQuestionById(id),
-    ]);
-    setAnswers(updated);
-    setQuestion(updatedQuestion);
-  };
-
+    const fetchData = async () => {
+      setIsLoading(true);
+      await refreshAnswers();
+      setIsLoading(false);
+    };
+    fetchData();
+  }, [id, refreshAnswers]);
 
   // 回答を投稿
-  const handlePostAnswer = async () => {
-    if (validate(answerContent, setAnswerError)) return;
+  const handlePostAnswer = async (content: string) => {
     if (!id) return;
-
-    setIsAnswerSubmitting(true);
-    try {
-      await postAnswer({ questionId: id, content: answerContent });
-      await refreshAnswers();
-      toast.success('回答を投稿しました');
-
-      setIsAnswerModalOpen(false);
-      setAnswerContent('');
-      setAnswerError('');
-    } catch {
-      // axiosClientがエラートーストを自動表示
-    } finally {
-      setIsAnswerSubmitting(false);
-    }
+    await postAnswer({ questionId: id, content });
+    await refreshAnswers();
+    toast.success('回答を投稿しました');
+    setIsAnswerModalOpen(false);
   };
-
-
-  // 回答への返信を投稿
-  const handlePostReply = async () => {
-    if (validate(replyContent, setReplyError)) return;
-    if (!replyTargetAnswerId || !id) return;
-
-    setIsReplySubmitting(true);
-    try {
-      await postAnswer({ questionId: id, content: replyContent, parentAnswerId: replyTargetAnswerId });
-      await refreshAnswers();
-      toast.success('回答を投稿しました');
-      setReplyTargetAnswerId(null);
-      setReplyContent('');
-      setReplyError('');
-    } catch {
-      setReplyError('返信の投稿に失敗しました');
-    } finally {
-      setIsReplySubmitting(false);
-    }
+  // 返信を投稿（回答への返信・スレッドへの返信を一括処理）
+  const handlePostReply = async (content: string) => {
+    if (!id || !replyTarget) return;
+    await postAnswer({
+      questionId: id,
+      content,
+      parentAnswerId: replyTarget.parentId
+    });
+    await refreshAnswers();
+    toast.success('返信を投稿しました');
+    setReplyTarget(null);
   };
-
-
-  // ThreadReply への返信を投稿
-  const handlePostThreadReply = async () => {
-    if (validate(replyContent, setReplyError)) return;
-    if (!replyTargetReply || !id) return;
-
-    setIsReplySubmitting(true);
-    try {
-      await postAnswer({ questionId: id, content: replyContent, parentAnswerId: replyTargetReply.id });
-      await refreshAnswers();
-      toast.success('回答を投稿しました');
-      setReplyTargetReply(null);
-      setReplyContent('');
-      setReplyError('');
-    } catch {
-      setReplyError('返信の投稿に失敗しました');
-    } finally {
-      setIsReplySubmitting(false);
-    }
-  };
-
-
-  // 質問を削除してトップへ戻る
   const handleDeleteQuestion = async () => {
     if (!id) return;
     try {
@@ -525,7 +117,6 @@ export default function QuestionPage() {
         prev.map((a) => ({ ...a, isBestAnswer: a.id === answerId }))
       );
       setQuestion((prev) => prev ? { ...prev, statusId: '解決済み' } : prev);
-      // バックエンドが返す message を表示（バックエンドで文言を調整済み）
       toast.success(res?.message || 'ベストアンサーに選びました');
     } catch (err) {
       console.error('ベストアンサー設定エラー:', err);
@@ -533,40 +124,28 @@ export default function QuestionPage() {
     }
   };
 
-
-  const replyTargetAnswer = answers.find((a) => a.id === replyTargetAnswerId);
-
-
   if (isLoading) {
     return (
-      <>
-        <div className="min-h-screen bg-[var(--base-color)] pt-[64px] flex items-center justify-center">
-          <Loading />
-        </div>
-      </>
+      <div className="min-h-screen bg-[var(--base-color)] pt-[64px] flex items-center justify-center">
+        <Loading />
+      </div>
     );
   }
 
   if (!question) {
     return (
-      <>
-        <div className="min-h-screen bg-[var(--base-color)] pt-[64px] flex items-center justify-center">
-          <p className="text-[var(--dark-gray)]">質問が見つかりません</p>
-        </div>
-      </>
+      <div className="min-h-screen bg-[var(--base-color)] pt-[64px] flex items-center justify-center">
+        <p className="text-[var(--dark-gray)]">質問が見つかりません</p>
+      </div>
     );
   }
-
 
   return (
     <>
       <div className="min-h-screen bg-[var(--base-color)] pt-[64px]">
         <div className="max-w-[1440px] mx-auto px-[var(--spacing-32)] py-[var(--spacing-24)] flex flex-col gap-[var(--spacing-24)]">
 
-          {isOwner
-            ? <QuestionDetailCard question={question} onDelete={handleDeleteQuestion} />
-            : <AnswererQuestionCard question={question} />
-          }
+          <QuestionDetailCard question={question} onDelete={handleDeleteQuestion} isOwner={isOwner} />
 
           <section className="flex flex-col gap-[var(--spacing-16)]">
             <div className="flex items-center justify-between border-b border-[var(--main-color)] py-[var(--spacing-16)]">
@@ -587,8 +166,8 @@ export default function QuestionPage() {
                     isOwner={isOwner}
                     currentUserId={user?.id ?? ''}
                     onBestAnswer={handleBestAnswer}
-                    onReply={(answerId) => setReplyTargetAnswerId(answerId)}
-                    onThreadReply={(preview) => setReplyTargetReply(preview)}
+                    onReply={(answerId) => setReplyTarget({ parentId: answerId, type: 'answer', previewData: answer })}
+                    onThreadReply={(preview) => setReplyTarget({ parentId: preview.id, type: 'thread', previewData: preview })}
                     onDeleteAnswer={handleDeleteAnswer}
                     onDeleteReply={handleDeleteAnswer}
                   />
@@ -607,47 +186,28 @@ export default function QuestionPage() {
 
       {/* 回答投稿モーダル */}
       {isAnswerModalOpen && (
-        <Modal confirmOnClose onClose={() => { setIsAnswerModalOpen(false); setAnswerContent(''); setAnswerError(''); }}>
-          <AnswerForm
-            title="回答を入力してください"
-            preview={<AnswererQuestionPreviewCard question={question} />}
-            content={answerContent}
-            onChange={setAnswerContent}
-            error={answerError}
-            isSubmitting={isAnswerSubmitting}
-            onSubmit={handlePostAnswer}
-          />
-        </Modal>
+        <AnswerFormModal
+          title="回答を入力してください"
+          submitText="回答送信"
+          preview={<AnswererQuestionPreviewCard question={question} />}
+          onClose={() => setIsAnswerModalOpen(false)}
+          onSubmit={handlePostAnswer}
+        />
       )}
 
-      {/* 回答への返信モーダル */}
-      {replyTargetAnswerId !== null && replyTargetAnswer && (
-        <Modal confirmOnClose onClose={() => { setReplyTargetAnswerId(null); setReplyContent(''); setReplyError(''); }}>
-          <AnswerForm
-            title="返信を入力してください"
-            preview={<AnswerPreviewCard answer={replyTargetAnswer} />}
-            content={replyContent}
-            onChange={setReplyContent}
-            error={replyError}
-            isSubmitting={isReplySubmitting}
-            onSubmit={handlePostReply}
-          />
-        </Modal>
-      )}
-
-      {/* ThreadReply への返信モーダル */}
-      {replyTargetReply !== null && (
-        <Modal confirmOnClose onClose={() => { setReplyTargetReply(null); setReplyContent(''); setReplyError(''); }}>
-          <AnswerForm
-            title="返信を入力してください"
-            preview={<ReplyPreviewCard reply={replyTargetReply} />}
-            content={replyContent}
-            onChange={setReplyContent}
-            error={replyError}
-            isSubmitting={isReplySubmitting}
-            onSubmit={handlePostThreadReply}
-          />
-        </Modal>
+      {/* 返信モーダル（回答向け・スレッド向け共通処理） */}
+      {replyTarget && (
+        <AnswerFormModal
+          title="返信を入力してください"
+          submitText="返信送信"
+          preview={
+            replyTarget.type === 'answer'
+              ? <AnswerPreviewCard answer={replyTarget.previewData} />
+              : <ReplyPreviewCard reply={replyTarget.previewData} />
+          }
+          onClose={() => setReplyTarget(null)}
+          onSubmit={handlePostReply}
+        />
       )}
     </>
   );


### PR DESCRIPTION
## 概要
`routes/question.tsx`（質問詳細ページ）に肥大化して混在していた各種カードコンポーネントや、モーダルに関連する入力フォームのロジック・State（状態管理）を別コンポーネントへ切り出し、コードの可読性と保守性を向上させるリファクタリングを行いました。

## 変更内容

### 1. サブコンポーネントの切り出し・ファイル分割
UIとロジックの関心事を分離するため、以下の3つのファイルを新しく作成し、コンポーネントを切り出しました。

- **`src/components/questionDetail/AnswerCard.tsx` (新規)**
  - 従来は親ページ内に直書きされていた回答表示用のメインコンポーネント `AnswerCard` を別ファイルに切り出し、独立させました。
- **`src/components/questionDetail/QuestionPreviewCards.tsx` (新規)**
  - モーダル内でのみ使用されていた各種プレビュー用カード（`AnswererQuestionPreviewCard`, `AnswerPreviewCard`, `ReplyPreviewCard`）を1つのファイルに集約・独立させました。
- **`src/components/questionDetail/AnswerFormModal.tsx` (新規)**
  - 従来は親ページ側で別々に持っていた「回答用」「返信用」のUI構造を共通化。さらに、フォームの入力値（`content`）、エラー状態（`error`）、送信中フラグ（`isSubmitting`）などの内部Stateをこのモーダル内にカプセル化しました。

### 2. `src/routes/question.tsx`（親ページ）のクリーンアップ
- フォーム周りのStateや主要コンポーネントを子側に移させたことで、親コンポーネントのコード量を大幅に削減（メインロジックの配置とデータ管理に集中）させました。
- 「回答への返信」と「スレッド内のリプライ」で重複していたモーダルの管理Stateおよび投稿ロジックを一元化し、`replyTarget` という1つのStateで処理できるように統合しました。
- 新しいAPI仕様（`CommonResponse` によるメッセージ取得やトースト対応など）への刷新を行いました。

## 影響範囲
- 質問詳細ページ（`/questions/:id`）における「回答一覧の表示」「回答作成」「回答への返信」「スレッド内のリプライ」の一連の挙動。

## レビューで確認してほしいポイント
1. ページ読み込み、回答一覧の表示、および各種削除・ベストアンサー選定の挙動に問題がないか。
2. 回答作成モーダル、および2種類の返信モーダル（回答宛・リプライ宛）がState統合後も期待通りにデータが渡り、正常に送信できるか。
3. 新規に切り出した各ファイルへのインポートパスや型定義に違和感がないか。