### PR TITLE
fix: UIおよびバックエンドの各種不具合を修正

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,7 +10,7 @@ import aiRouter from './routes/ai';
 import statusRouter from './routes/statuses';
 
 const app = express();
-app.use(cors());
+app.use(cors({ origin: process.env.FRONTEND_URL || 'http://localhost:5173' }));
 app.use(express.json());
 
 app.get('/', (req, res) => res.json({ message: 'Hello from Express!' }));

--- a/frontend/app/components/common/Bookmark.tsx
+++ b/frontend/app/components/common/Bookmark.tsx
@@ -48,9 +48,6 @@ export default function Bookmark({ isBookmarked, count, id }: BookmarkProps) {
             setIsPending(false);
         }
     }
-    useEffect(() => {
-
-    }, [])
     return (
         <div className='inline-flex items-center gap-1'>
             <BookmarkIcon

--- a/frontend/app/components/common/Like.tsx
+++ b/frontend/app/components/common/Like.tsx
@@ -52,7 +52,8 @@ export default function Like({ isLiked, count, id, type }: LikeProps) {
             // APIが失敗した場合は、ステートを元の状態に巻き戻す
             setLikedState(likedState);
             setCountState(countState);
-            toast.error(nextLiked ? '質問へのいいねに失敗しました。' : '質問のいいね解除に失敗しました。');
+            const itemType = type === 'question' ? '質問' : '回答';
+            toast.error(nextLiked ? `${itemType}へのいいねに失敗しました。` : `${itemType}のいいね解除に失敗しました。`);
         } finally {
             setIsPending(false);
         }
@@ -62,7 +63,7 @@ export default function Like({ isLiked, count, id, type }: LikeProps) {
         <div className='inline-flex items-center gap-1'>
             <FavoriteIcon
                 className={`cursor-pointer transition-colors ${likedState ? 'text-[var(--like-color)]' : 'text-[var(--light-gray)]'
-                    } ${isPending ? 'opacity-50 Fpointer-events-none' : ''}`}
+                    } ${isPending ? 'opacity-50 pointer-events-none' : ''}`}
                 onClick={handleClick}
             />
             <span>{countState}</span>

--- a/frontend/app/components/questionDetail/QuestionDetailCard.tsx
+++ b/frontend/app/components/questionDetail/QuestionDetailCard.tsx
@@ -52,7 +52,7 @@ export default function QuestionDetailCard({ question, onDelete }: QuestionDetai
                 <CardActionMenu
                     isContentOpen={isContentOpen}
                     setIsContentOpen={setIsContentOpen}
-                    onRemove={handleRemove}
+                    onRemove={onDelete ? handleRemove : undefined}
                     isOverflowing={isOverflowing}
                 />
             </div>


### PR DESCRIPTION
- Like: isPending中のクリック無効化クラス名のtypoを修正 (Fpointer-events-none → pointer-events-none)
- Like: いいね失敗時のトーストメッセージをtypeに応じて質問/回答で出し分けるよう修正
- Bookmark: 空のuseEffectを削除
- QuestionDetailCard: onDeleteがundefinedの場合にCardActionMenuのonRemoveもundefinedを渡すよう修正
- index.ts: CORS設定にorigin制限を追加 (FRONTEND_URL環境変数またはlocalhost:5173)