### PR TITLE
feat: 管理画面を実装

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,6 +8,7 @@ import answerRouter from './routes/answer';
 import tagsRouter from './routes/tags';
 import aiRouter from './routes/ai';
 import statusRouter from './routes/statuses';
+import adminRouter from './routes/admin';
 
 const app = express();
 app.use(cors());
@@ -21,6 +22,7 @@ app.use('/api/v1/answers', answerRouter);
 app.use('/api/v1/tags', tagsRouter);
 app.use('/api/v1/statuses', statusRouter);
 app.use('/api/v1/ai', aiRouter);
+app.use('/api/v1/admin', adminRouter);
 
 const port = Number(process.env.PORT) || 3001;
 app.listen(port, () => console.log(`Server running on http://localhost:${port}`));

--- a/backend/src/middleware/adminAuth.ts
+++ b/backend/src/middleware/adminAuth.ts
@@ -1,0 +1,20 @@
+import { Request, Response, NextFunction } from 'express';
+import { requireAuth } from './auth.js';
+import { supabaseAdmin } from '../config/supabase.js';
+
+export async function requireAdmin(req: Request, res: Response, next: NextFunction): Promise<void> {
+  await requireAuth(req, res, async () => {
+    const { data: user } = await supabaseAdmin
+      .from('users')
+      .select('is_admin')
+      .eq('id', req.user!.id)
+      .single();
+
+    if (!user?.is_admin) {
+      res.status(403).json({ error: '管理者権限が必要です' });
+      return;
+    }
+
+    next();
+  });
+}

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,0 +1,312 @@
+import { Router } from 'express';
+import { supabaseAdmin } from '../config/supabase.js';
+import { requireAdmin } from '../middleware/adminAuth.js';
+
+const router = Router();
+
+// 統計情報
+// GET /api/v1/admin/stats
+router.get('/stats', requireAdmin, async (req, res) => {
+  const [
+    { count: userCount },
+    { count: questionCount },
+    { count: tagCount },
+  ] = await Promise.all([
+    supabaseAdmin.from('users').select('id', { count: 'exact', head: true }),
+    supabaseAdmin.from('questions').select('id', { count: 'exact', head: true }).is('deleted_at', null),
+    supabaseAdmin.from('tags').select('id', { count: 'exact', head: true }),
+  ]);
+
+  return res.json({
+    userCount: userCount ?? 0,
+    questionCount: questionCount ?? 0,
+    tagCount: tagCount ?? 0,
+  });
+});
+
+// ユーザー一覧
+// GET /api/v1/admin/users?page=1&search=
+router.get('/users', requireAdmin, async (req, res) => {
+  const page = Number(req.query.page) || 1;
+  const search = req.query.search as string | undefined;
+  const limit = 20;
+  const offset = (page - 1) * limit;
+
+  let query = supabaseAdmin
+    .from('users')
+    .select('id, nickname, profile_icon_url, is_admin, created_at', { count: 'exact' })
+    .order('created_at', { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (search) {
+    query = query.ilike('nickname', `%${search}%`);
+  }
+
+  const { data: users, error, count } = await query;
+
+  if (error) {
+    console.error('Admin users fetch error:', error);
+    return res.status(500).json({ error: 'ユーザー一覧の取得に失敗しました' });
+  }
+
+  const userIds = (users ?? []).map((u: any) => u.id);
+
+  const [{ data: questionRows }, { data: answerRows }] = await Promise.all([
+    supabaseAdmin.from('questions').select('user_id').in('user_id', userIds).is('deleted_at', null),
+    supabaseAdmin.from('answers').select('user_id').in('user_id', userIds).is('deleted_at', null),
+  ]);
+
+  const qMap: Record<string, number> = {};
+  (questionRows ?? []).forEach((q: any) => { qMap[q.user_id] = (qMap[q.user_id] ?? 0) + 1; });
+  const aMap: Record<string, number> = {};
+  (answerRows ?? []).forEach((a: any) => { aMap[a.user_id] = (aMap[a.user_id] ?? 0) + 1; });
+
+  const formatted = (users ?? []).map((u: any) => ({
+    id: u.id,
+    nickname: u.nickname,
+    iconUrl: u.profile_icon_url ?? '',
+    isAdmin: u.is_admin ?? false,
+    createdAt: u.created_at,
+    questionCount: qMap[u.id] ?? 0,
+    answerCount: aMap[u.id] ?? 0,
+  }));
+
+  return res.json({
+    data: formatted,
+    totalCount: count ?? 0,
+    totalPages: Math.ceil((count ?? 0) / limit),
+    currentPage: page,
+  });
+});
+
+// ユーザー詳細
+// GET /api/v1/admin/users/:userId
+router.get('/users/:userId', requireAdmin, async (req, res) => {
+  const { userId } = req.params;
+
+  const { data: user, error } = await supabaseAdmin
+    .from('users')
+    .select('id, nickname, profile_icon_url, is_admin, created_at')
+    .eq('id', userId)
+    .single();
+
+  if (error || !user) {
+    return res.status(404).json({ error: 'ユーザーが見つかりません' });
+  }
+
+  const [{ count: questionCount }, { count: answerCount }, { count: bestAnswerCount }] = await Promise.all([
+    supabaseAdmin.from('questions').select('id', { count: 'exact', head: true }).eq('user_id', userId).is('deleted_at', null),
+    supabaseAdmin.from('answers').select('id', { count: 'exact', head: true }).eq('user_id', userId).is('deleted_at', null),
+    supabaseAdmin.from('answers').select('id', { count: 'exact', head: true }).eq('user_id', userId).not('best_answer_at', 'is', null),
+  ]);
+
+  return res.json({
+    id: (user as any).id,
+    nickname: (user as any).nickname,
+    iconUrl: (user as any).profile_icon_url ?? '',
+    isAdmin: (user as any).is_admin ?? false,
+    createdAt: (user as any).created_at,
+    questionCount: questionCount ?? 0,
+    answerCount: answerCount ?? 0,
+    bestAnswerCount: bestAnswerCount ?? 0,
+  });
+});
+
+// ユーザー削除（完全削除）
+// DELETE /api/v1/admin/users/:userId
+router.delete('/users/:userId', requireAdmin, async (req, res) => {
+  const { userId } = req.params;
+  const requestingUserId = req.user!.id;
+
+  if (userId === requestingUserId) {
+    return res.status(400).json({ error: '自分自身は削除できません' });
+  }
+
+  const { error } = await supabaseAdmin.auth.admin.deleteUser(userId);
+  if (error) {
+    console.error('Auth delete error:', error);
+    return res.status(500).json({ error: 'ユーザーの削除に失敗しました' });
+  }
+
+  return res.status(200).json({ message: 'ユーザーを削除しました' });
+});
+
+// 管理者権限の付与・剥奪
+// PATCH /api/v1/admin/users/:userId/admin
+router.patch('/users/:userId/admin', requireAdmin, async (req, res) => {
+  const { userId } = req.params;
+  const requestingUserId = req.user!.id;
+  const { isAdmin } = req.body as { isAdmin?: boolean };
+
+  if (typeof isAdmin !== 'boolean') {
+    return res.status(400).json({ error: 'isAdminはboolean型である必要があります' });
+  }
+  if (userId === requestingUserId && !isAdmin) {
+    return res.status(400).json({ error: '自分自身の管理者権限は剥奪できません' });
+  }
+
+  const { error } = await supabaseAdmin
+    .from('users')
+    .update({ is_admin: isAdmin })
+    .eq('id', userId);
+
+  if (error) {
+    console.error('Admin toggle error:', error);
+    return res.status(500).json({ error: '管理者権限の変更に失敗しました' });
+  }
+
+  return res.status(200).json({ message: isAdmin ? '管理者権限を付与しました' : '管理者権限を剥奪しました' });
+});
+
+// 質問一覧
+// GET /api/v1/admin/questions?page=1&keyword=
+router.get('/questions', requireAdmin, async (req, res) => {
+  const page = Number(req.query.page) || 1;
+  const keyword = req.query.keyword as string | undefined;
+  const limit = 20;
+  const offset = (page - 1) * limit;
+
+  let query = supabaseAdmin
+    .from('questions')
+    .select(`
+      id,
+      title,
+      created_at,
+      statuses ( name ),
+      users ( nickname, profile_icon_url ),
+      question_tags ( tags ( name ) )
+    `, { count: 'exact' })
+    .is('deleted_at', null)
+    .order('created_at', { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (keyword) {
+    query = query.or(`title.ilike.%${keyword}%,content.ilike.%${keyword}%`);
+  }
+
+  const { data: questions, error, count } = await query;
+
+  if (error) {
+    console.error('Admin questions fetch error:', error);
+    return res.status(500).json({ error: '質問一覧の取得に失敗しました' });
+  }
+
+  const formatted = (questions ?? []).map((q: any) => ({
+    id: q.id,
+    title: q.title,
+    userName: q.users?.nickname ?? '(退会済み)',
+    iconUrl: q.users?.profile_icon_url ?? '',
+    statusId: q.statuses?.name ?? '',
+    tagNames: q.question_tags?.map((qt: any) => qt.tags?.name).filter(Boolean) ?? [],
+    postingTime: q.created_at,
+  }));
+
+  return res.json({
+    data: formatted,
+    totalCount: count ?? 0,
+    totalPages: Math.ceil((count ?? 0) / limit),
+    currentPage: page,
+  });
+});
+
+// 質問削除（soft delete）
+// DELETE /api/v1/admin/questions/:questionId
+router.delete('/questions/:questionId', requireAdmin, async (req, res) => {
+  const { questionId } = req.params;
+
+  const { error } = await supabaseAdmin
+    .from('questions')
+    .update({ deleted_at: new Date().toISOString() })
+    .eq('id', questionId)
+    .is('deleted_at', null);
+
+  if (error) {
+    console.error('Admin question delete error:', error);
+    return res.status(500).json({ error: '質問の削除に失敗しました' });
+  }
+
+  return res.status(200).json({ message: '質問を削除しました' });
+});
+
+// タグ一覧（使用中の質問数付き）
+// GET /api/v1/admin/tags
+router.get('/tags', requireAdmin, async (req, res) => {
+  const { data: tags, error } = await supabaseAdmin
+    .from('tags')
+    .select('id, name, question_tags ( question_id )')
+    .order('name', { ascending: true });
+
+  if (error) {
+    console.error('Admin tags fetch error:', error);
+    return res.status(500).json({ error: 'タグ一覧の取得に失敗しました' });
+  }
+
+  const formatted = (tags ?? []).map((t: any) => ({
+    id: t.id,
+    name: t.name,
+    questionCount: t.question_tags?.length ?? 0,
+  }));
+
+  return res.json(formatted);
+});
+
+// タグ作成
+// POST /api/v1/admin/tags
+router.post('/tags', requireAdmin, async (req, res) => {
+  const { name } = req.body as { name?: unknown };
+
+  if (typeof name !== 'string' || name.trim().length < 1 || name.trim().length > 20) {
+    return res.status(400).json({ error: 'タグ名は1〜20文字で入力してください' });
+  }
+
+  const trimmedName = name.trim();
+
+  const { data: existing } = await supabaseAdmin
+    .from('tags')
+    .select('id')
+    .eq('name', trimmedName)
+    .maybeSingle();
+
+  if (existing) {
+    return res.status(409).json({ error: '同名のタグが既に存在します' });
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from('tags')
+    .insert({ name: trimmedName })
+    .select('id, name')
+    .single();
+
+  if (error || !data) {
+    console.error('Tag create error:', error);
+    return res.status(500).json({ error: 'タグの作成に失敗しました' });
+  }
+
+  return res.status(201).json({ message: `タグ「${(data as any).name}」を作成しました` });
+});
+
+// タグ削除（使用中は不可）
+// DELETE /api/v1/admin/tags/:tagId
+router.delete('/tags/:tagId', requireAdmin, async (req, res) => {
+  const { tagId } = req.params;
+
+  const { count } = await supabaseAdmin
+    .from('question_tags')
+    .select('question_id', { count: 'exact', head: true })
+    .eq('tag_id', tagId);
+
+  if ((count ?? 0) > 0) {
+    return res.status(409).json({ error: `このタグは${count}件の質問で使用中のため削除できません` });
+  }
+
+  const { error } = await supabaseAdmin.from('tags').delete().eq('id', tagId);
+
+  if (error) {
+    console.error('Tag delete error:', error);
+    return res.status(500).json({ error: 'タグの削除に失敗しました' });
+  }
+
+  return res.status(200).json({ message: 'タグを削除しました' });
+});
+
+export default router;

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -99,7 +99,7 @@ router.get('/me', requireAuth, async (req, res) => {
   // ユーザー基本情報取得
   const { data: user, error: userError } = await supabase
     .from('users')
-    .select('id, nickname, profile_icon_url')
+    .select('id, nickname, profile_icon_url, is_admin')
     .eq('id', userId)
     .maybeSingle();
 
@@ -151,6 +151,7 @@ router.get('/me', requireAuth, async (req, res) => {
     id: user.id,
     nickname: user.nickname,
     iconUrl: user.profile_icon_url,
+    isAdmin: (user as any).is_admin ?? false,
     questionCount: questionCount ?? 0,
     answerCount: answerCount ?? 0,
     bestAnswerCount: bestAnswerCount ?? 0,

--- a/frontend/app/api/adminService.ts
+++ b/frontend/app/api/adminService.ts
@@ -1,0 +1,51 @@
+import axiosClient from './axiosClient';
+import type { AdminStats, AdminUser, AdminUserDetail, AdminQuestion, AdminTag, PaginatedResponse } from '@/types/admin';
+
+export const getAdminStats = async (): Promise<AdminStats> => {
+  const res = await axiosClient.get<AdminStats>('admin/stats');
+  return res.data;
+};
+
+export const getAdminUsers = async (page = 1, search?: string): Promise<PaginatedResponse<AdminUser>> => {
+  const res = await axiosClient.get<PaginatedResponse<AdminUser>>('admin/users', {
+    params: { page, search },
+  });
+  return res.data;
+};
+
+export const getAdminUserDetail = async (userId: string): Promise<AdminUserDetail> => {
+  const res = await axiosClient.get<AdminUserDetail>(`admin/users/${userId}`);
+  return res.data;
+};
+
+export const deleteAdminUser = async (userId: string): Promise<void> => {
+  await axiosClient.delete(`admin/users/${userId}`);
+};
+
+export const toggleAdminRole = async (userId: string, isAdmin: boolean): Promise<void> => {
+  await axiosClient.patch(`admin/users/${userId}/admin`, { isAdmin });
+};
+
+export const getAdminQuestions = async (page = 1, keyword?: string): Promise<PaginatedResponse<AdminQuestion>> => {
+  const res = await axiosClient.get<PaginatedResponse<AdminQuestion>>('admin/questions', {
+    params: { page, keyword },
+  });
+  return res.data;
+};
+
+export const deleteAdminQuestion = async (questionId: string): Promise<void> => {
+  await axiosClient.delete(`admin/questions/${questionId}`);
+};
+
+export const getAdminTags = async (): Promise<AdminTag[]> => {
+  const res = await axiosClient.get<AdminTag[]>('admin/tags');
+  return res.data;
+};
+
+export const createAdminTag = async (name: string): Promise<void> => {
+  await axiosClient.post('admin/tags', { name });
+};
+
+export const deleteAdminTag = async (tagId: string): Promise<void> => {
+  await axiosClient.delete(`admin/tags/${tagId}`);
+};

--- a/frontend/app/api/axiosClient.ts
+++ b/frontend/app/api/axiosClient.ts
@@ -96,7 +96,7 @@ axiosClient.interceptors.response.use(
                     errorMessage = "対象のデータが見つかりません。";
                     break;
                 case 409:
-                    errorMessage = "すでに登録されています。";
+                    errorMessage = error.response.data?.error || "すでに登録されています。";
                     break;
                 case 500:
                     errorMessage = "サーバー内部でエラーが発生しました。";

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -10,5 +10,12 @@ export default [
     route("create-question", "routes/createQuestion.tsx"),
     route("question/:id", "routes/question.tsx"),
     route("profile", "routes/profile.tsx"),
+
+    route("admin", "routes/admin/layout.tsx", [
+      index("routes/admin/index.tsx"),
+      route("users", "routes/admin/users.tsx"),
+      route("questions", "routes/admin/questions.tsx"),
+      route("tags", "routes/admin/tags.tsx"),
+    ]),
   ]),
 ] satisfies RouteConfig;

--- a/frontend/app/routes/admin/index.tsx
+++ b/frontend/app/routes/admin/index.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import Card from '@/components/common/Card';
+import { getAdminStats } from '@/api/adminService';
+import type { AdminStats } from '@/types/admin';
+import PeopleIcon from '@mui/icons-material/People';
+import QuestionAnswerIcon from '@mui/icons-material/QuestionAnswer';
+import LabelIcon from '@mui/icons-material/Label';
+
+export default function AdminDashboard() {
+  const [stats, setStats] = useState<AdminStats | null>(null);
+
+  useEffect(() => {
+    getAdminStats().then(setStats).catch(console.error);
+  }, []);
+
+  const statItems = [
+    { label: '総ユーザー数', value: stats?.userCount, icon: PeopleIcon, color: 'var(--main-color)' },
+    { label: '総質問数', value: stats?.questionCount, icon: QuestionAnswerIcon, color: 'var(--accent-color)' },
+    { label: '総タグ数', value: stats?.tagCount, icon: LabelIcon, color: 'var(--status-color-organize)' },
+  ];
+
+  return (
+    <div>
+      <h2 className="text-[length:var(--font-size-big)] font-bold mb-8">ダッシュボード</h2>
+      <div className="grid grid-cols-3 gap-6">
+        {statItems.map(({ label, value, icon: Icon, color }) => (
+          <Card key={label} className="flex items-center gap-6 !p-6">
+            <div
+              className="w-14 h-14 rounded-full flex items-center justify-center flex-shrink-0"
+              style={{ backgroundColor: color + '20' }}
+            >
+              <Icon style={{ color, fontSize: 28 }} />
+            </div>
+            <div>
+              <p className="text-[var(--dark-gray)] text-sm">{label}</p>
+              <p className="text-[length:var(--font-size-big)] font-bold mt-1">
+                {value ?? '—'}
+              </p>
+            </div>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes/admin/layout.tsx
+++ b/frontend/app/routes/admin/layout.tsx
@@ -1,0 +1,61 @@
+import { NavLink, Outlet, redirect } from 'react-router';
+import { getMyData } from '@/api/userService';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import PeopleIcon from '@mui/icons-material/People';
+import QuestionAnswerIcon from '@mui/icons-material/QuestionAnswer';
+import LabelIcon from '@mui/icons-material/Label';
+
+export async function clientLoader() {
+  try {
+    const userData = await getMyData();
+    if (!userData.isAdmin) {
+      return redirect('/top');
+    }
+    return null;
+  } catch {
+    return redirect('/top');
+  }
+}
+
+const navItems = [
+  { to: '/admin', label: 'ダッシュボード', icon: DashboardIcon, end: true },
+  { to: '/admin/users', label: 'ユーザー管理', icon: PeopleIcon, end: false },
+  { to: '/admin/questions', label: '質問管理', icon: QuestionAnswerIcon, end: false },
+  { to: '/admin/tags', label: 'タグ管理', icon: LabelIcon, end: false },
+];
+
+export default function AdminLayout() {
+  return (
+    <div className="flex h-[calc(100vh-64px)]">
+      <aside className="w-56 bg-white shadow-[var(--box-shadow)] flex-shrink-0 flex flex-col overflow-y-auto">
+        <div className="px-5 py-5 border-b border-[var(--light-gray)]">
+          <p className="text-xs text-[var(--dark-gray)] mb-1">KnowHub</p>
+          <h1 className="text-[length:var(--font-size-medium)] font-bold text-[var(--main-color)]">管理画面</h1>
+        </div>
+        <nav className="flex-1 p-3 space-y-1">
+          {navItems.map(({ to, label, icon: Icon, end }) => (
+            <NavLink
+              key={to}
+              to={to}
+              end={end}
+              className={({ isActive }) =>
+                `flex items-center gap-3 px-4 py-3 rounded-[var(--radius-small)] text-[length:var(--font-size-normal)] transition-colors ${
+                  isActive
+                    ? 'bg-[var(--main-color)] text-white'
+                    : 'text-[var(--text-color-black)] hover:bg-[var(--hover-color)]'
+                }`
+              }
+            >
+              <Icon className="!text-[20px]" />
+              {label}
+            </NavLink>
+          ))}
+        </nav>
+      </aside>
+
+      <main className="flex-1 overflow-y-auto bg-[var(--base-color)] p-8">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/frontend/app/routes/admin/questions.tsx
+++ b/frontend/app/routes/admin/questions.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from 'react';
+import { getAdminQuestions, deleteAdminQuestion } from '@/api/adminService';
+import type { AdminQuestion } from '@/types/admin';
+import StatusChip from '@/components/common/StatusChip';
+import TagChip from '@/components/common/TagChip';
+import TextInput from '@/components/common/TextInput';
+import Modal from '@/components/common/Modal';
+import Avatar from '@/components/common/Avatar';
+import DeleteIcon from '@mui/icons-material/Delete';
+import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
+import NavigateNextIcon from '@mui/icons-material/NavigateNext';
+
+const formatDate = (d: string) =>
+  new Date(d).toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' });
+
+export default function AdminQuestions() {
+  const [questions, setQuestions] = useState<AdminQuestion[]>([]);
+  const [totalPages, setTotalPages] = useState(1);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [keywordInput, setKeywordInput] = useState('');
+  const [keyword, setKeyword] = useState('');
+  const [deleteTarget, setDeleteTarget] = useState<AdminQuestion | null>(null);
+
+  const loadQuestions = async (page: number, kw: string) => {
+    try {
+      const result = await getAdminQuestions(page, kw || undefined);
+      setQuestions(result.data);
+      setTotalPages(result.totalPages || 1);
+    } catch { /* axiosClient handles errors */ }
+  };
+
+  useEffect(() => { loadQuestions(currentPage, keyword); }, [currentPage, keyword]);
+
+  const handleSearch = () => { setCurrentPage(1); setKeyword(keywordInput); };
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteAdminQuestion(deleteTarget.id);
+      setDeleteTarget(null);
+      loadQuestions(currentPage, keyword);
+    } catch { setDeleteTarget(null); }
+  };
+
+  return (
+    <div>
+      <h2 className="text-[length:var(--font-size-big)] font-bold mb-6">質問管理</h2>
+
+      <div className="w-80 mb-6">
+        <TextInput
+          placeholder="タイトルで検索..."
+          value={keywordInput}
+          onChange={setKeywordInput}
+          isSearch
+          onSearch={handleSearch}
+          onKeyDown={e => e.key === 'Enter' && handleSearch()}
+        />
+      </div>
+
+      <div className="bg-white rounded-[var(--radius-big)] shadow-[var(--box-shadow)] overflow-hidden">
+        <table className="w-full">
+          <thead>
+            <tr className="bg-[var(--hover-color)] border-b border-[var(--light-gray)]">
+              <th className="text-left px-4 py-3 text-sm text-[var(--dark-gray)] font-medium">タイトル</th>
+              <th className="text-left px-4 py-3 text-sm text-[var(--dark-gray)] font-medium">投稿者</th>
+              <th className="text-left px-4 py-3 text-sm text-[var(--dark-gray)] font-medium">ステータス</th>
+              <th className="text-left px-4 py-3 text-sm text-[var(--dark-gray)] font-medium">タグ</th>
+              <th className="text-left px-4 py-3 text-sm text-[var(--dark-gray)] font-medium">投稿日</th>
+              <th className="px-4 py-3 w-12"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {questions.map(q => (
+              <tr key={q.id} className="border-b border-[var(--light-gray)] hover:bg-[var(--hover-color)] transition-colors">
+                <td className="px-4 py-3 max-w-[240px]">
+                  <span className="line-clamp-2 text-sm">{q.title}</span>
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-2">
+                    <Avatar src={q.iconUrl} className="w-7 h-7" />
+                    <span className="text-sm">{q.userName}</span>
+                  </div>
+                </td>
+                <td className="px-4 py-3">
+                  <StatusChip name={q.statusId} />
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex flex-wrap gap-1">
+                    {q.tagNames.slice(0, 2).map(tag => (
+                      <TagChip key={tag} text={tag} />
+                    ))}
+                    {q.tagNames.length > 2 && (
+                      <span className="text-xs text-[var(--dark-gray)] self-center">+{q.tagNames.length - 2}</span>
+                    )}
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-sm text-[var(--dark-gray)] whitespace-nowrap">
+                  {formatDate(q.postingTime)}
+                </td>
+                <td className="px-4 py-3">
+                  <button onClick={() => setDeleteTarget(q)}
+                    className="p-2 text-[var(--danger-color)] hover:bg-red-50 rounded transition-colors">
+                    <DeleteIcon className="!text-[20px]" />
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {questions.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-4 py-12 text-center text-[var(--dark-gray)]">
+                  質問が見つかりません
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-4 mt-6">
+          <button disabled={currentPage <= 1} onClick={() => setCurrentPage(p => p - 1)}
+            className="p-2 rounded hover:bg-[var(--hover-color)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+            <NavigateBeforeIcon />
+          </button>
+          <span className="text-sm text-[var(--dark-gray)]">{currentPage} / {totalPages}</span>
+          <button disabled={currentPage >= totalPages} onClick={() => setCurrentPage(p => p + 1)}
+            className="p-2 rounded hover:bg-[var(--hover-color)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+            <NavigateNextIcon />
+          </button>
+        </div>
+      )}
+
+      {/* 削除確認モーダル */}
+      {deleteTarget && (
+        <Modal onClose={() => setDeleteTarget(null)}>
+          <div className="text-center w-full">
+            <p className="text-[length:var(--font-size-medium)] font-bold mb-4">質問を削除しますか？</p>
+            <p className="text-[var(--dark-gray)] mb-2 text-sm">
+              「<strong>{deleteTarget.title}</strong>」を削除します。
+            </p>
+            <p className="text-[var(--danger-color)] text-sm mb-8">この操作は取り消せません。</p>
+            <div className="flex gap-4 justify-center">
+              <button onClick={() => setDeleteTarget(null)}
+                className="px-8 py-3 rounded-[var(--radius-small)] border border-[var(--light-gray)] hover:bg-gray-50 transition-colors">
+                キャンセル
+              </button>
+              <button onClick={handleDeleteConfirm}
+                className="px-8 py-3 rounded-[var(--radius-small)] bg-[var(--danger-color)] text-white font-medium hover:opacity-90 transition-opacity">
+                削除する
+              </button>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/routes/admin/tags.tsx
+++ b/frontend/app/routes/admin/tags.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from 'react';
+import { getAdminTags, createAdminTag, deleteAdminTag } from '@/api/adminService';
+import type { AdminTag } from '@/types/admin';
+import TextInput from '@/components/common/TextInput';
+import Modal from '@/components/common/Modal';
+import DeleteIcon from '@mui/icons-material/Delete';
+import LabelIcon from '@mui/icons-material/Label';
+import AddIcon from '@mui/icons-material/Add';
+
+export default function AdminTags() {
+  const [tags, setTags] = useState<AdminTag[]>([]);
+  const [newTagName, setNewTagName] = useState('');
+  const [deleteTarget, setDeleteTarget] = useState<AdminTag | null>(null);
+
+  const loadTags = async () => {
+    try {
+      setTags(await getAdminTags());
+    } catch { /* axiosClient handles errors */ }
+  };
+
+  useEffect(() => { loadTags(); }, []);
+
+  const handleCreate = async () => {
+    if (!newTagName.trim()) return;
+    try {
+      await createAdminTag(newTagName);
+      setNewTagName('');
+      loadTags();
+    } catch { /* axiosClient handles errors */ }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteAdminTag(deleteTarget.id);
+      setDeleteTarget(null);
+      loadTags();
+    } catch { setDeleteTarget(null); }
+  };
+
+  return (
+    <div>
+      <h2 className="text-[length:var(--font-size-big)] font-bold mb-6">タグ管理</h2>
+
+      {/* 新規作成フォーム */}
+      <div className="bg-white rounded-[var(--radius-big)] shadow-[var(--box-shadow)] p-6 mb-6">
+        <h3 className="text-[length:var(--font-size-medium)] font-medium mb-4">新規タグ作成</h3>
+        <div className="flex gap-4 items-center">
+          <div className="w-72">
+            <TextInput
+              placeholder="タグ名（1〜20文字）"
+              value={newTagName}
+              onChange={setNewTagName}
+              onKeyDown={e => e.key === 'Enter' && handleCreate()}
+            />
+          </div>
+          <button
+            onClick={handleCreate}
+            disabled={!newTagName.trim()}
+            className="flex items-center gap-2 px-6 py-2 bg-[image:var(--gradation-green)] text-white rounded-[var(--radius-small)] disabled:opacity-40 disabled:cursor-not-allowed hover:opacity-90 transition-opacity"
+          >
+            <AddIcon className="!text-[18px]" />
+            作成する
+          </button>
+        </div>
+      </div>
+
+      {/* タグ一覧 */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+        {tags.map(tag => (
+          <div
+            key={tag.id}
+            className="bg-white rounded-[var(--radius-big)] shadow-[var(--box-shadow)] p-4 flex items-center justify-between gap-2"
+          >
+            <div className="flex items-center gap-2 min-w-0">
+              <LabelIcon className="!text-[18px] text-[var(--main-color)] flex-shrink-0" />
+              <span className="font-medium truncate">{tag.name}</span>
+              <span className="text-xs text-[var(--dark-gray)] flex-shrink-0">({tag.questionCount})</span>
+            </div>
+            <button
+              onClick={() => setDeleteTarget(tag)}
+              disabled={tag.questionCount > 0}
+              title={tag.questionCount > 0 ? `${tag.questionCount}件の質問で使用中` : 'タグを削除'}
+              className="p-1 text-[var(--danger-color)] hover:bg-red-50 rounded transition-colors disabled:opacity-30 disabled:cursor-not-allowed flex-shrink-0"
+            >
+              <DeleteIcon className="!text-[18px]" />
+            </button>
+          </div>
+        ))}
+        {tags.length === 0 && (
+          <div className="col-span-full text-center py-12 text-[var(--dark-gray)]">
+            タグがありません
+          </div>
+        )}
+      </div>
+
+      {/* 削除確認モーダル */}
+      {deleteTarget && (
+        <Modal onClose={() => setDeleteTarget(null)}>
+          <div className="text-center w-full">
+            <p className="text-[length:var(--font-size-medium)] font-bold mb-4">タグを削除しますか？</p>
+            <p className="text-[var(--dark-gray)] mb-8">
+              「<strong>{deleteTarget.name}</strong>」を削除します。
+            </p>
+            <div className="flex gap-4 justify-center">
+              <button onClick={() => setDeleteTarget(null)}
+                className="px-8 py-3 rounded-[var(--radius-small)] border border-[var(--light-gray)] hover:bg-gray-50 transition-colors">
+                キャンセル
+              </button>
+              <button onClick={handleDeleteConfirm}
+                className="px-8 py-3 rounded-[var(--radius-small)] bg-[var(--danger-color)] text-white font-medium hover:opacity-90 transition-opacity">
+                削除する
+              </button>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/routes/admin/users.tsx
+++ b/frontend/app/routes/admin/users.tsx
@@ -1,0 +1,240 @@
+import { useEffect, useState } from 'react';
+import Avatar from '@/components/common/Avatar';
+import Modal from '@/components/common/Modal';
+import TextInput from '@/components/common/TextInput';
+import { getAdminUsers, getAdminUserDetail, deleteAdminUser, toggleAdminRole } from '@/api/adminService';
+import type { AdminUser, AdminUserDetail } from '@/types/admin';
+import { useUser } from '@/contexts/UserContext';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
+import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
+import NavigateNextIcon from '@mui/icons-material/NavigateNext';
+
+const formatDate = (d: string) =>
+  new Date(d).toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' });
+
+export default function AdminUsers() {
+  const { user: currentUser } = useUser();
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [totalPages, setTotalPages] = useState(1);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [searchInput, setSearchInput] = useState('');
+  const [search, setSearch] = useState('');
+  const [selectedUser, setSelectedUser] = useState<AdminUser | null>(null);
+  const [userDetail, setUserDetail] = useState<AdminUserDetail | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<AdminUser | null>(null);
+
+  const loadUsers = async (page: number, q: string) => {
+    try {
+      const result = await getAdminUsers(page, q || undefined);
+      setUsers(result.data);
+      setTotalPages(result.totalPages || 1);
+    } catch { /* axiosClient handles errors */ }
+  };
+
+  useEffect(() => { loadUsers(currentPage, search); }, [currentPage, search]);
+
+  const handleSearch = () => { setCurrentPage(1); setSearch(searchInput); };
+
+  const openDetail = async (user: AdminUser) => {
+    setSelectedUser(user);
+    setUserDetail(null);
+    try {
+      const detail = await getAdminUserDetail(user.id);
+      setUserDetail(detail);
+    } catch { /* axiosClient handles errors */ }
+  };
+
+  const handleToggleAdmin = async (userId: string, newIsAdmin: boolean) => {
+    try {
+      await toggleAdminRole(userId, newIsAdmin);
+      const update = (u: AdminUser) => u.id === userId ? { ...u, isAdmin: newIsAdmin } : u;
+      setUsers(prev => prev.map(update));
+      setSelectedUser(prev => prev && prev.id === userId ? { ...prev, isAdmin: newIsAdmin } : prev);
+      setUserDetail(prev => prev && prev.id === userId ? { ...prev, isAdmin: newIsAdmin } : prev);
+    } catch { /* axiosClient handles errors */ }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteAdminUser(deleteTarget.id);
+      setDeleteTarget(null);
+      setSelectedUser(null);
+      setUserDetail(null);
+      loadUsers(currentPage, search);
+    } catch { setDeleteTarget(null); }
+  };
+
+  return (
+    <div>
+      <h2 className="text-[length:var(--font-size-big)] font-bold mb-6">ユーザー管理</h2>
+
+      <div className="w-80 mb-6">
+        <TextInput
+          placeholder="ニックネームで検索..."
+          value={searchInput}
+          onChange={setSearchInput}
+          isSearch
+          onSearch={handleSearch}
+          onKeyDown={e => e.key === 'Enter' && handleSearch()}
+        />
+      </div>
+
+      <div className="bg-white rounded-[var(--radius-big)] shadow-[var(--box-shadow)] overflow-hidden">
+        <table className="w-full">
+          <thead>
+            <tr className="bg-[var(--hover-color)] border-b border-[var(--light-gray)]">
+              <th className="text-left px-4 py-3 text-sm text-[var(--dark-gray)] font-medium">ユーザー</th>
+              <th className="text-center px-4 py-3 text-sm text-[var(--dark-gray)] font-medium">質問数</th>
+              <th className="text-center px-4 py-3 text-sm text-[var(--dark-gray)] font-medium">回答数</th>
+              <th className="text-center px-4 py-3 text-sm text-[var(--dark-gray)] font-medium">権限</th>
+              <th className="text-left px-4 py-3 text-sm text-[var(--dark-gray)] font-medium">登録日</th>
+              <th className="px-4 py-3 w-12"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map(user => (
+              <tr
+                key={user.id}
+                className="border-b border-[var(--light-gray)] hover:bg-[var(--hover-color)] transition-colors cursor-pointer"
+                onClick={() => openDetail(user)}
+              >
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-3">
+                    <Avatar src={user.iconUrl} className="w-9 h-9" />
+                    <span className="font-medium">{user.nickname ?? '(未設定)'}</span>
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-center">{user.questionCount}</td>
+                <td className="px-4 py-3 text-center">{user.answerCount}</td>
+                <td className="px-4 py-3 text-center">
+                  {user.isAdmin && (
+                    <span className="inline-flex items-center gap-1 px-2 py-1 bg-[var(--main-color)] text-white text-xs rounded-full">
+                      <AdminPanelSettingsIcon className="!text-[12px]" />
+                      管理者
+                    </span>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-[var(--dark-gray)] text-sm">{formatDate(user.createdAt)}</td>
+                <td className="px-4 py-3" onClick={e => { e.stopPropagation(); setDeleteTarget(user); }}>
+                  <button
+                    disabled={user.id === currentUser?.id}
+                    className="p-2 text-[var(--danger-color)] hover:bg-red-50 rounded transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                  >
+                    <DeleteIcon className="!text-[20px]" />
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {users.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-4 py-12 text-center text-[var(--dark-gray)]">
+                  ユーザーが見つかりません
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-4 mt-6">
+          <button disabled={currentPage <= 1} onClick={() => setCurrentPage(p => p - 1)}
+            className="p-2 rounded hover:bg-[var(--hover-color)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+            <NavigateBeforeIcon />
+          </button>
+          <span className="text-sm text-[var(--dark-gray)]">{currentPage} / {totalPages}</span>
+          <button disabled={currentPage >= totalPages} onClick={() => setCurrentPage(p => p + 1)}
+            className="p-2 rounded hover:bg-[var(--hover-color)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+            <NavigateNextIcon />
+          </button>
+        </div>
+      )}
+
+      {/* ユーザー詳細モーダル */}
+      {selectedUser && (
+        <Modal onClose={() => { setSelectedUser(null); setUserDetail(null); }}>
+          <div className="w-full">
+            <div className="flex items-center gap-4 mb-6">
+              <Avatar src={selectedUser.iconUrl} className="w-16 h-16" />
+              <div>
+                <h3 className="text-[length:var(--font-size-medium)] font-bold">
+                  {selectedUser.nickname ?? '(未設定)'}
+                </h3>
+                <p className="text-sm text-[var(--dark-gray)] mt-1">登録日: {formatDate(selectedUser.createdAt)}</p>
+                {selectedUser.isAdmin && (
+                  <span className="inline-flex items-center gap-1 px-2 py-1 bg-[var(--main-color)] text-white text-xs rounded-full mt-1">
+                    <AdminPanelSettingsIcon className="!text-[12px]" />
+                    管理者
+                  </span>
+                )}
+              </div>
+            </div>
+
+            {userDetail && (
+              <div className="grid grid-cols-3 gap-4 mb-6">
+                {[
+                  { label: '質問数', value: userDetail.questionCount },
+                  { label: '回答数', value: userDetail.answerCount },
+                  { label: 'ベストアンサー', value: userDetail.bestAnswerCount },
+                ].map(({ label, value }) => (
+                  <div key={label} className="bg-[var(--hover-color)] rounded-[var(--radius-small)] p-4 text-center">
+                    <p className="text-2xl font-bold text-[var(--main-color)]">{value}</p>
+                    <p className="text-sm text-[var(--dark-gray)] mt-1">{label}</p>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {currentUser?.id !== selectedUser.id && (
+              <div className="flex flex-col gap-3">
+                <button
+                  onClick={() => handleToggleAdmin(selectedUser.id, !selectedUser.isAdmin)}
+                  className={`flex items-center justify-center gap-2 w-full py-3 rounded-[var(--radius-small)] border-2 font-medium transition-colors ${
+                    selectedUser.isAdmin
+                      ? 'border-[var(--dark-gray)] text-[var(--dark-gray)] hover:bg-gray-50'
+                      : 'border-[var(--main-color)] text-[var(--main-color)] hover:bg-[var(--hover-color)]'
+                  }`}
+                >
+                  <AdminPanelSettingsIcon />
+                  {selectedUser.isAdmin ? '管理者権限を剥奪する' : '管理者権限を付与する'}
+                </button>
+                <button
+                  onClick={() => { setDeleteTarget(selectedUser); setSelectedUser(null); setUserDetail(null); }}
+                  className="flex items-center justify-center gap-2 w-full py-3 rounded-[var(--radius-small)] border-2 border-[var(--danger-color)] text-[var(--danger-color)] font-medium hover:bg-red-50 transition-colors"
+                >
+                  <DeleteIcon />
+                  このユーザーを削除する
+                </button>
+              </div>
+            )}
+          </div>
+        </Modal>
+      )}
+
+      {/* 削除確認モーダル */}
+      {deleteTarget && (
+        <Modal onClose={() => setDeleteTarget(null)}>
+          <div className="text-center w-full">
+            <p className="text-[length:var(--font-size-medium)] font-bold mb-4">ユーザーを削除しますか？</p>
+            <p className="text-[var(--dark-gray)] mb-2">
+              <strong>{deleteTarget.nickname ?? '(未設定)'}</strong> を完全に削除します。
+            </p>
+            <p className="text-[var(--danger-color)] text-sm mb-8">この操作は取り消せません。</p>
+            <div className="flex gap-4 justify-center">
+              <button onClick={() => setDeleteTarget(null)}
+                className="px-8 py-3 rounded-[var(--radius-small)] border border-[var(--light-gray)] hover:bg-gray-50 transition-colors">
+                キャンセル
+              </button>
+              <button onClick={handleDeleteConfirm}
+                className="px-8 py-3 rounded-[var(--radius-small)] bg-[var(--danger-color)] text-white font-medium hover:opacity-90 transition-opacity">
+                削除する
+              </button>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/types/admin.ts
+++ b/frontend/app/types/admin.ts
@@ -1,0 +1,42 @@
+export type AdminUser = {
+  id: string;
+  nickname: string | null;
+  iconUrl: string;
+  isAdmin: boolean;
+  createdAt: string;
+  questionCount: number;
+  answerCount: number;
+};
+
+export type AdminUserDetail = AdminUser & {
+  bestAnswerCount: number;
+};
+
+export type AdminQuestion = {
+  id: string;
+  title: string;
+  userName: string;
+  iconUrl: string;
+  statusId: string;
+  tagNames: string[];
+  postingTime: string;
+};
+
+export type AdminTag = {
+  id: string;
+  name: string;
+  questionCount: number;
+};
+
+export type AdminStats = {
+  userCount: number;
+  questionCount: number;
+  tagCount: number;
+};
+
+export type PaginatedResponse<T> = {
+  data: T[];
+  totalCount: number;
+  totalPages: number;
+  currentPage: number;
+};

--- a/frontend/app/types/user.ts
+++ b/frontend/app/types/user.ts
@@ -2,6 +2,7 @@ export interface myData {
     id: string
     nickname: string
     iconUrl: string
+    isAdmin: boolean
     questionCount: number
     answerCount: number
     bestAnswerCount: number


### PR DESCRIPTION
## バックエンド
- adminAuth ミドルウェアを追加（is_admin チェック）
- /api/v1/admin/* ルートを追加
  - GET /stats: ダッシュボード統計
  - GET/DELETE /users, GET /users/:id, PATCH /users/:id/admin: ユーザー管理
  - GET/DELETE /questions: 質問管理
  - GET/POST/DELETE /tags: タグ管理
- users/me レスポンスに isAdmin を追加

## フロントエンド
- /admin 以下のルートを追加（auth-guard 配下）
- 管理者チェック付きレイアウト（サイドバー）
- ダッシュボード（統計カード）
- ユーザー一覧・詳細モーダル・管理者権限付与/剥奪・削除
- 質問一覧・削除
- タグ一覧・作成・削除
- axiosClient の 409 エラーメッセージをサーバー側のメッセージ優先に修正