### PR TITLE
fix: 管理画面のユーザー削除時にFKエラーで部分削除が起きる問題を修正

### DIFF
--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -122,6 +122,19 @@ router.delete('/users/:userId', requireAdmin, async (req, res) => {
     return res.status(400).json({ error: '自分自身は削除できません' });
   }
 
+  // auth.admin.deleteUser は auth.users を削除し public.users へのカスケードを
+  // 引き起こすが、notifications / likes / bookmarks が users.id を NOT NULL FK で
+  // 参照しているため先にそれらを削除する必要がある。
+  // 質問・回答は user_id を null にして "(退会済み)" として残す。
+  await supabaseAdmin.from('notifications').delete().eq('receiver_user_id', userId);
+  await supabaseAdmin.from('notifications').delete().eq('sender_user_id', userId);
+  await supabaseAdmin.from('question_likes').delete().eq('user_id', userId);
+  await supabaseAdmin.from('answer_likes').delete().eq('user_id', userId);
+  await supabaseAdmin.from('bookmarks').delete().eq('user_id', userId);
+  await supabaseAdmin.from('questions').update({ user_id: null }).eq('user_id', userId);
+  await supabaseAdmin.from('answers').update({ user_id: null }).eq('user_id', userId);
+  await supabaseAdmin.from('users').delete().eq('id', userId);
+
   const { error } = await supabaseAdmin.auth.admin.deleteUser(userId);
   if (error) {
     console.error('Auth delete error:', error);


### PR DESCRIPTION
 ## 原因
   `auth.admin.deleteUser()` が `auth.users` を削除する際、`public.users` へのカスケード削除が走るが、以下のテーブルが `users.id` を NOT NULL FK で参照しているためFK制約違反が発生していた。

   - `notifications` (receiver_user_id / sender_user_id)
   - `question_likes` (user_id)
   - `answer_likes` (user_id)
   - `bookmarks` (user_id)
   -    -    - 
 ## 修正内容
   `auth.admin.deleteUser()` を呼ぶ前に依存関係を全て解消する処理を追加。

   1. notifications（送受信両方）を削除
   2. question_likes / answer_likes / bookmarks を削除
   3. questions / answers の `user_id` を `null` に更新（投稿は "退会済み" として残す）
   4. `public.users` を明示的に削除
   5. `auth.admin.deleteUser()` を呼ぶ

   ## 対応が必要な既存データ

   すでに部分削除状態（auth削除済み・public.users残存）になっているユーザーについては、Supabase ダッシュボードの SQL エディタで手動クリーンアップが必要。

   ## Test plan
   - [ ] 管理画面からユーザーを削除してエラーが出ないことを確認
   - [ ] 削除されたユーザーがログインできないことを確認
   - [ ] 削除されたユーザーの投稿が "(退会済み)" として表示されることを確認
   - [ ] 自分自身を削除しようとすると 400 エラーになることを確認